### PR TITLE
feat(scripts): uses next dev instead of vercel dev

### DIFF
--- a/template/_package.json
+++ b/template/_package.json
@@ -7,7 +7,7 @@
     "cypress:run": "cypress run",
     "cypress:local": "CYPRESS_LOCAL=true CYPRESS_BASE_URL=http://localhost:3000 cypress",
     "db:migrate": "yarn -s prisma migrate up --experimental",
-    "dev": "concurrently -n \"WATCHERS,VERCEL\" -c \"black.bgYellow.dim,black.bgCyan.dim\" \"yarn watch:all\" \"vc dev\"",
+    "dev": "concurrently -n \"WATCHERS,NEXT\" -c \"black.bgYellow.dim,black.bgCyan.dim\" \"yarn watch:all\" \"next dev\"",
     "g:cell": "hygen cell new --name",
     "g:component": "hygen component new --name",
     "g:graphql": "hygen graphql new --name",


### PR DESCRIPTION
We can keep this more generic by using `next dev` instead. This still reads env vars.