### PR TITLE
fix(generators): fix bug in component path

### DIFF
--- a/template/_templates/component/new/new.ejs
+++ b/template/_templates/component/new/new.ejs
@@ -1,5 +1,5 @@
 ---
-to: components/<%= h.inflection.camelize(h.dirName(name)) %>/<%= h.camelizedBaseName(name) %>.tsx
+to: components/<%= [h.inflection.camelize(h.dirName(name)), h.camelizedBaseName(name)].filter(Boolean).join('/') %>.tsx
 ---
 <% formattedPath = h.camelizedPathName(name) -%>
 <% component = h.camelizedBaseName(name) -%>


### PR DESCRIPTION
This fixes an issue where the generators tried to create a directory like `components//MyComponent.tsx`.