### PR TITLE
fix(types): run nexus build during setup.

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,6 +132,14 @@ module.exports = (name) => {
       },
     },
     {
+      title: "Generate Nexus types",
+      task: async () => {
+        return execa("yarn", ["nexus", "build", "--no-bundle"], {
+          cwd: pkgName,
+        });
+      },
+    },
+    {
       title: "Cleanup",
       task: async () => {
         return Promise.all([


### PR DESCRIPTION
This is required to run tests without errors. Prior to this, users would need to run it manually.

## Changes

- Generates the Nexus types during initial setup

## Screenshots

![image](https://user-images.githubusercontent.com/14339/90313935-31554800-dede-11ea-8590-0554602d5244.png)


## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works

Fixes #21 
