### PR TITLE
fix(env): add default APP_SECRET value to test env

### DIFF
--- a/template/_.env.test
+++ b/template/_.env.test
@@ -1,3 +1,4 @@
 # ENV vars here override .env when running tests
 
 DATABASE_URL="postgresql://postgres@localhost:5432/%NAME%_test?schema=public"
+APP_SECRET=foo


### PR DESCRIPTION
A default `APP_SECRET` was not added to .env.test and was causing tests to fail in the generated app.

## Changes

- Adds default value for `APP_SECRET` to .env.test

## Screenshots

Prevents the following:
![image](https://user-images.githubusercontent.com/14339/90314090-12a38100-dedf-11ea-9748-4b0d00b2917b.png)

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works

Fixes #20 