### PR TITLE
fix(cli): generate prisma client before nexus types

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,6 +132,14 @@ module.exports = (name) => {
       },
     },
     {
+      title: "Generate Prisma client",
+      task: async () => {
+        return execa("yarn", ["prisma", "generate"], {
+          cwd: pkgName,
+        });
+      },
+    },
+    {
       title: "Generate Nexus types",
       task: async () => {
         return execa("yarn", ["nexus", "build", "--no-bundle"], {


### PR DESCRIPTION
This prevents an error on installation. We need to generate Prisma types before we try and generate anything with Nexus.

## Changes

- Adds "Generate Prisma client" step


## Screenshots

![image](https://user-images.githubusercontent.com/14339/90555695-c5851080-e165-11ea-8191-7fb3e5a65284.png)

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works

Fixes #24 
