### PR TITLE
fix: schema value referenced is null resulting in the schema not being dropped during jest teardown

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+Description of PR that completes issue here...
+
+## Changes
+
+- Description of changes
+
+
+## Screenshots
+
+(prefer animated gif)
+
+
+## Checklist
+
+- [ ] Requires dependency update?
+- [ ] Generating a new app works
+
+Fixes #xxx

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Echobind
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ Using npx:
 npx create-bison-app MyApp
 ```
 
-## Migrate the database
+## Setup the database
 
-1. Migrate the database with `yarn db:migrate`. You'll be prompted to create the database if it doesn't exist:
+1. Setup your local database with `yarn db:setup`. You'll be prompted to create it if it doesn't already exist:
 
 ![Prisma DB Create Prompt](https://user-images.githubusercontent.com/14339/88480536-7e1fb180-cf24-11ea-85c9-9bed43c9dfe4.png)
 

--- a/index.js
+++ b/index.js
@@ -132,6 +132,14 @@ module.exports = (name) => {
       },
     },
     {
+      title: "Generate Prisma client",
+      task: async () => {
+        return execa("yarn", ["prisma", "generate"], {
+          cwd: pkgName,
+        });
+      },
+    },
+    {
       title: "Generate Nexus types",
       task: async () => {
         return execa("yarn", ["nexus", "build", "--no-bundle"], {

--- a/index.js
+++ b/index.js
@@ -132,6 +132,14 @@ module.exports = (name) => {
       },
     },
     {
+      title: "Generate Nexus types",
+      task: async () => {
+        return execa("yarn", ["nexus", "build", "--no-bundle"], {
+          cwd: pkgName,
+        });
+      },
+    },
+    {
       title: "Cleanup",
       task: async () => {
         return Promise.all([

--- a/postInstallText.js
+++ b/postInstallText.js
@@ -4,7 +4,7 @@ All set! To finalize setup, do the following:
 
 cd %NAME%
 
-* Migrate your database with \`yarn db:migrate\`. You will be prompted to create it if necessary.
+* Setup your database with \`yarn db:setup\`. You will be prompted to create it if necessary.
 * Run the app with \`yarn dev\`. This will start the dev server and watchers for generating types.
 * Create a new GitHub repo, and push the code from your newly generated app.
 * Set ENV vars for CI and Deployment

--- a/template/README.md
+++ b/template/README.md
@@ -32,9 +32,9 @@ To run the app locally:
 1. If this is a new project, keep all the build defaults. If this is an existing project, choose "link to an existing project" when prompted.
 1. If setting up an existing project, run `vc env pull`. This will sync your dev env vars and save them to .env.
 
-## Migrate the database
+## Setup the database
 
-1. Migrate the database with `yarn db:migrate`. You'll be prompted to create the database if it doesn't exist:
+1. Setup your local database with `yarn db:setup`. You'll be prompted to create it if it doesn't already exist:
 
 ![Prisma DB Create Prompt](https://user-images.githubusercontent.com/14339/88480536-7e1fb180-cf24-11ea-85c9-9bed43c9dfe4.png)
 
@@ -44,7 +44,7 @@ If you'd like to change the database name or schema, change the DATABASE_URL in 
 
 From the root, run `yarn dev`. This:
 
-- runs `vc dev` to run the frontend and serverless functions locally
+- runs `next dev` to run the frontend and serverless functions locally
 - starts a watcher to generate the Prisma client on schema changes
 - starts a watcher to generate TypeScript types for GraphQL files
 

--- a/template/_.env.local
+++ b/template/_.env.local
@@ -1,2 +1,3 @@
 # ENV vars here override .env when running locally
 # DATABASE_URL="postgresql://postgres@localhost:5432/%NAME%_dev?schema=public"
+APP_SECRET=foo

--- a/template/_.env.test
+++ b/template/_.env.test
@@ -1,3 +1,4 @@
 # ENV vars here override .env when running tests
 
 DATABASE_URL="postgresql://postgres@localhost:5432/%NAME%_test?schema=public"
+APP_SECRET=foo

--- a/template/_package.json
+++ b/template/_package.json
@@ -7,6 +7,7 @@
     "cypress:run": "cypress run",
     "cypress:local": "CYPRESS_LOCAL=true CYPRESS_BASE_URL=http://localhost:3000 cypress",
     "db:migrate": "yarn -s prisma migrate up --experimental",
+    "db:setup": "yarn db:migrate && yarn prisma generate",
     "dev": "concurrently -n \"WATCHERS,NEXT\" -c \"black.bgYellow.dim,black.bgCyan.dim\" \"yarn watch:all\" \"next dev\"",
     "g:cell": "hygen cell new --name",
     "g:component": "hygen component new --name",

--- a/template/tests/jest.setup.js
+++ b/template/tests/jest.setup.js
@@ -15,7 +15,7 @@ module.exports = async () => {
   // console.log(`[jest] server is up...`);
 
   global.schema = `test_${nanoid().toLowerCase()}`;
-  global.databaseUrl = `postgresql://postgres:postgres@localhost:5432/testing?schema=${this.schema}`;
+  global.databaseUrl = `postgresql://postgres:postgres@localhost:5432/testing?schema=${global.schema}`;
 
   process.env.DATABASE_URL = global.databaseUrl;
   global.process.env.DATABASE_URL = global.databaseUrl;


### PR DESCRIPTION
Schema value reference in jest setup script is null/undefined. This results in the teardown script failing to drop the temporary test schema.

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works
