### PR TITLE
chore: run GitHub Actions on main and next

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
+      - next
 
 jobs:
   release:

--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
     "semantic-release": "^17.1.1"
   },
   "release": {
+    "branches": [
+      "main",
+      "next"
+    ],
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",


### PR DESCRIPTION
This updates GH actions workflow and semantic release to use `main and `next` branches

## Changes

- Updates release GH Actions workflow
- Updates semantic release branch config

## Screenshots

n/a


## Checklist

- [ ] Requires dependency update?
- [ ] Generating a new app works

Fixes #32 
