### PR TITLE
fix: include postInstallText in package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "index.js",
     "cli.js",
     "template",
-    "postInstallText.js"
+    "postInstallText.ejs"
   ],
   "keywords": [
     "bison",


### PR DESCRIPTION
This was an oversight when moving to ejs...

## Changes

- Make sure it's included.


## Screenshots

n/a


## Checklist

- [ ] Requires dependency update?
- [ ] Generating a new app works