### PR TITLE
fix: setError errorOption

### DIFF
--- a/template/utils/setErrors.ts
+++ b/template/utils/setErrors.ts
@@ -1,4 +1,4 @@
-import { ErrorOption } from 'react-hook-form/dist/types/form';
+import ErrorOption from 'react-hook-form/dist/types/form';
 
 /**
  * Sets errors on the frontend from a GraphQL Response. Assumes react-hook-form.
@@ -12,7 +12,7 @@ export function setErrorsFromGraphQLErrors(setError: SetErrorFn, errors: ErrorRe
   });
 }
 
-type SetErrorFn = (e: string, obj: ErrorOption) => void;
+type SetErrorFn = (e: string, obj: typeof ErrorOption) => void;
 
 interface ErrorResponse {
   extensions: {

--- a/template/utils/setErrors.ts
+++ b/template/utils/setErrors.ts
@@ -1,4 +1,4 @@
-import ErrorOption from 'react-hook-form/dist/types/form';
+import { ErrorOption } from 'react-hook-form';
 
 /**
  * Sets errors on the frontend from a GraphQL Response. Assumes react-hook-form.
@@ -12,7 +12,7 @@ export function setErrorsFromGraphQLErrors(setError: SetErrorFn, errors: ErrorRe
   });
 }
 
-type SetErrorFn = (e: string, obj: typeof ErrorOption) => void;
+type SetErrorFn = (e: string, obj: ErrorOption) => void;
 
 interface ErrorResponse {
   extensions: {


### PR DESCRIPTION
Upgrade of react-hook-form created a type error deploying to Vercel

## Changes

removed curly braces and added typeof to setError.ts

## Screenshots

(prefer animated gif)


## Checklist

- [ ] Requires dependency update?
- [ ] Generating a new app works

Fixes #xxx
