### PR TITLE
chore: upgrade nexus-plugin-prisma package

### DIFF
--- a/template/package.json.ejs
+++ b/template/package.json.ejs
@@ -44,7 +44,7 @@
     "jsonwebtoken": "^8.5.1",
     "next": "9.4.4",
     "nexus": "^0.26.1",
-    "nexus-plugin-prisma": "^0.17.0",
+    "nexus-plugin-prisma": "^0.19.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-hook-form": "^6.1.0",


### PR DESCRIPTION
This PR upgrades the `nexus-plugin-prisma` package.

## Changes

- Version 0.18.0 of this package introduces various [BREAKING CHANGES](https://github.com/graphql-nexus/nexus-plugin-prisma/releases/tag/0.18.0). These should be reviewed by the development team prior to upgrading Bison.

## Checklist

- [x] Requires dependency update?
- [x] Generating a new app works