### PR TITLE
fix: remove deprecated prisma.connect from template

### DIFF
--- a/template/lib/prisma.ts
+++ b/template/lib/prisma.ts
@@ -19,7 +19,7 @@ export async function disconnect() {
 }
 
 export async function connect() {
-  await prisma.connect();
+  await prisma.$connect();
 
   return true;
 }


### PR DESCRIPTION
This moves to the non-deprecated [`prisma.$connect`](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/connection-management#connect) method. Like mentioned in #57, disconnect is already taken care of so this should be good to go in the next release.

## Changes

- prisma.connect -> prisma.$connect


## Screenshots

n/a

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works

Fixes #57 

## Merge #60 first