### PR TITLE
fix: use as prop on MenuButton to fix types

### DIFF
--- a/template/components/Nav.tsx
+++ b/template/components/Nav.tsx
@@ -1,5 +1,14 @@
 import React from 'react';
-import { Link, Stack, useBreakpoint, MenuButton, Menu, MenuList, MenuItem } from '@chakra-ui/core';
+import {
+  Link,
+  Stack,
+  useBreakpoint,
+  Button,
+  MenuButton,
+  Menu,
+  MenuList,
+  MenuItem,
+} from '@chakra-ui/core';
 import NextLink from 'next/link';
 
 export function Nav() {
@@ -8,7 +17,7 @@ export function Nav() {
 
   return isMobile ? (
     <Menu>
-      <MenuButton variant="outline" colorScheme="lightPurple" ml="auto">
+      <MenuButton as={Button} variant="outline" colorScheme="lightPurple" ml="auto">
         =
       </MenuButton>
 


### PR DESCRIPTION
Thanks to @agustif for the heads up on this one!

## Changes

- Menu button should use the `as` prop with Button


## Screenshots
Before:
![image](https://user-images.githubusercontent.com/14339/94629831-de6b0080-0291-11eb-82fe-efb54c726932.png)

After:
![image](https://user-images.githubusercontent.com/14339/94629844-eb87ef80-0291-11eb-89c7-07ece37cb9ca.png)


## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works

Fixes #58 