### PR TITLE
chore: extend the dev workflow doc with examples

### DIFF
--- a/docs/devWorkflow.md
+++ b/docs/devWorkflow.md
@@ -6,11 +6,92 @@ We start from the API and then create the frontend. The reason for this is that 
 
 ## API
 
-1. Generate a new GraphQL module using `yarn g:graphql`.
-1. Write a type, query, input, or mutation using [Nexus](https://nexusjs.org/guides/schema)
-1. Create a new request test using `yarn g:test:request`
-1. Run `yarn test` to start the test watcher
+### Generate a new GraphQL module
+
+```shell
+yarn g:graphql organization
+```
+
+This should output something like:
+
+```shell
+yarn run v1.22.10
+$ hygen graphql new --name organization
+
+Loaded templates: _templates
+       added: graphql/organization.ts
+      inject: graphql/schema.ts
+✨  Done in 0.34s.
+```
+
+### Update your Prisma schema
+
+Using our "organization" module example from the last step, we need to update `schema.prisma` with our data model:
+
+```javascript
+// prisma/schema.prisma
+
+model Organization {
+  id String @id @default(cuid())
+  name String
+  userId String
+  user User @relation(fields: [userId], references: [id])
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+```
+
+In our example a User has many Organizations, so we need to update our User model as well to reflect this relationship:
+
+```javascript
+// prisma/schema.prisma
+
+model User {
+  id        String   @id @default(cuid())
+  email     String   @unique
+  password  String
+  roles     Role[]
+  profile   Profile?
+  organizations Organization[]
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+```
+
+Note that we have defined `organizations` as `Organization[]`.
+
+### Run your migrations
+
+This is currently a two step process, 1) generate the migration and 2) execute the migration
+
+**Generate the migration**
+
+```shell
+yarn g:migration
+```
+
+**Execute the migration**
+
+```shell
+yarn db:migrate
+```
+
+## Write a type, query, input, or mutation using [Nexus](https://nexusjs.org/guides/schema)
+
+```
+# TODO
+```
+
+## Create a new request test
+
+```shell
+yarn g:test:request
+```
+
+## Run `yarn test` to start the test watcher
+
 1. Add tests cases and update schema code accordingly. The GraphQL playground (localhost:3000/api/graphql) can be helpful to form the proper queries to use in tests.
+
 1. `types.ts` and `api.graphql` should update automatically as you change files. Sometimes it's helpful to open these as a sanity check before moving on to the frontend code.
 
 ## Frontend

--- a/docs/devWorkflow.md
+++ b/docs/devWorkflow.md
@@ -8,6 +8,8 @@ We start from the API and then create the frontend. The reason for this is that 
 
 ### Generate a new GraphQL module
 
+To generate a new GraphQL module we can run the command `yarn g:graphql MODULE_NAME`, replacing MODULE_NAME with the name of your module. In our example, we'll be using the concept of an `Organization`.
+
 ```shell
 yarn g:graphql organization
 ```


### PR DESCRIPTION
[rendered](https://github.com/echobind/bisonapp/blob/chore/update-dev-workflow-doc/docs/devWorkflow.md)

This PR extends the dev workflow doc to include 1) examples for the API and 2) add the Prisma schema step.

## Changes

- Adds example utilizing the real-world example of `Organization` type
- Includes Prisma schema step

## Checklist

- [ ] Requires dependency update?
- [ ] Generating a new app works