### PR TITLE
fix: replace queryType with extendType

### DIFF
--- a/template/_templates/graphql/new/graphql.ejs
+++ b/template/_templates/graphql/new/graphql.ejs
@@ -27,7 +27,8 @@ export const CallPreference = enumType({
 });
 
 // Queries
-schema.queryType({
+schema.extendType({
+  type: 'Query',
   definition: (t) => {
     // List <%= plural %> Query (admin only)
     t.crud.<%= plural.toLowerCase() %>({


### PR DESCRIPTION
Nexus will error out if a previous `queryType` is already defined. We're planning to include a "global" that sets this - so ensuring that generated modules just extend Query will ensure this error does not happen for a dev.

## Changes

- Replaces `queryType` in our generated template with `extendType`

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works
