### PR TITLE
fix(npm): include utils folder in final package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "index.js",
     "cli.js",
     "template",
+    "utils",
     "postInstallText.ejs"
   ],
   "keywords": [


### PR DESCRIPTION
In the last PR, the `utils` folder wasn't added to the final package output, so once installed it failed to locate the file.

## Changes

- add utils to files property of package.json


## Screenshots

n/a


## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works

Fixes #70 