### PR TITLE
fix: remove nexus build from build script

### DIFF
--- a/template/package.json.ejs
+++ b/template/package.json.ejs
@@ -6,7 +6,10 @@
   "cacheDirectories": [".next/cache"],
 <% } -%>
   "scripts": {
-    "build": "next build",
+    "build": "yarn build:nexus && yarn build:prisma && yarn build:next",
+    "build:prisma": "prisma generate",
+    "build:next": "next build",
+    "build:nexus": "ts-node -P tsconfig.cjs.json --transpile-only graphql/schema.ts",
     "cypress:run": "cypress run",
     "cypress:local": "CYPRESS_LOCAL=true CYPRESS_BASE_URL=http://localhost:3000 cypress",
     "db:migrate": "yarn -s prisma migrate up --experimental",

--- a/template/package.json.ejs
+++ b/template/package.json.ejs
@@ -6,7 +6,7 @@
   "cacheDirectories": [".next/cache"],
 <% } -%>
   "scripts": {
-    "build": "yarn nexus build && next build",
+    "build": "next build",
     "cypress:run": "cypress run",
     "cypress:local": "CYPRESS_LOCAL=true CYPRESS_BASE_URL=http://localhost:3000 cypress",
     "db:migrate": "yarn -s prisma migrate up --experimental",


### PR DESCRIPTION
This was missed in #68. Additionally, we needed a few additional build scripts to ensure a proper production build.

## Changes

- add nexus, next, and prisma build scripts to ensure a proper production build.


## Screenshots

n/a

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works

Fixes #72 