### PR TITLE
fix:  lint error in dropDatabase broke codegen

### DIFF
--- a/template/scripts/dropDatabase.ts
+++ b/template/scripts/dropDatabase.ts
@@ -1,6 +1,8 @@
 export {};
 
+// eslint-disable-next-line
 const url = require('url');
+
 const Client = require('pg').Client;
 
 const connectionString = process.env.DATABASE_URL;


### PR DESCRIPTION
There was a linting error in the `dropDatabase` script that was causing codegen to fail.

## Changes

- disable eslint in the script

## Screenshots

Before:
<img width="710" alt="CleanShot 2020-10-10 at 11 29 44@2x" src="https://user-images.githubusercontent.com/14339/95660083-7ae39d00-0af3-11eb-89bf-49768b778170.png">

After:
<img width="490" alt="CleanShot 2020-10-10 at 12 17 39@2x" src="https://user-images.githubusercontent.com/14339/95660087-7cad6080-0af3-11eb-80e9-c16cd7be0818.png">


## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works

Fixes #78