### PR TITLE
fix: fix prisma gen folder path, upgrade prisma client & nexus plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,14 +152,6 @@ module.exports = async ({ name, ...answers }) => {
       },
     },
     {
-      title: "Generate Prisma client",
-      task: async () => {
-        return execa("yarn", ["prisma", "generate"], {
-          cwd: pkgName,
-        });
-      },
-    },
-    {
       title: "Git init",
       task: async () => {
         const repo = await nodegit.Repository.init(targetFolder, 0);

--- a/template/package.json.ejs
+++ b/template/package.json.ejs
@@ -45,7 +45,7 @@
     "@chakra-ui/theme": "^1.0.0-rc.0",
     "@chakra-ui/theme-tools": "^1.0.0-rc.0",
     "@nexus/schema": "^0.16.0",
-    "@prisma/client": "2.7.0",
+    "@prisma/client": "2.8.1",
 <% if (host.name === 'vercel') { -%>
     "apollo-server-micro": "^2.18.1",
 <% } -%>
@@ -59,7 +59,7 @@
     "graphql-type-json": "^0.3.1",
     "jsonwebtoken": "^8.5.1",
     "next": "9.5.3",
-    "nexus-plugin-prisma": "^0.20.0",
+    "nexus-plugin-prisma": "^0.21.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-hook-form": "^6.1.0",
@@ -72,7 +72,7 @@
     "@graphql-codegen/typescript-operations": "^1.17.6",
     "@graphql-codegen/typescript-react-apollo": "1.17.6",
     "@graphql-codegen/typescript-resolvers": "1.17.4",
-    "@prisma/cli": "2.7.0",
+    "@prisma/cli": "2.8.1",
     "@testing-library/cypress": "^6.0.0",
     "@testing-library/dom": "^7.21.7",
     "@testing-library/jest-dom": "^5.11.2",


### PR DESCRIPTION
This PR fixes an issue generating the prisma client. It also upgrades prisma and the nexus plugin for a few related fixes.

**Nexus Plugin updates (https://github.com/graphql-nexus/nexus-plugin-prisma/releases/tag/0.21.0):** 
![image](https://user-images.githubusercontent.com/14339/95694053-cedaa880-0bfd-11eb-8043-7360a9c35c68.png)

---

**Prisma updates (https://github.com/prisma/prisma/releases):**
![image](https://user-images.githubusercontent.com/14339/95694112-3db80180-0bfe-11eb-8b37-70f6338aff04.png)
![image](https://user-images.githubusercontent.com/14339/95694122-4a3c5a00-0bfe-11eb-9003-a605da8763a3.png)

Even though I can't fully reproduce it, it should also fix the issue discovered in #76.

## Changes

- Upgrade prisma to 2.8.1
- Upgrade Nexus Prisma Plugin to 0.21


## Screenshots

n/a


## Checklist

- [x] Requires dependency update?
- [x] Generating a new app works

Fixes #76 