### PR TITLE
fix: use path.cwd to determine paths for typegen

### DIFF
--- a/cypress/integration/createBisonAppWithDefaults.test.js
+++ b/cypress/integration/createBisonAppWithDefaults.test.js
@@ -6,6 +6,11 @@ describe("Creating a new app", () => {
     cy.get("h2").contains(/home page/i);
   });
 
+  it("properly renders the playground", () => {
+    cy.visit("/api/graphql");
+    cy.title().should("include", "Playground");
+  });
+
   describe("prisma .env", () => {
     it("contains the proper database URL", () => {
       cy.task("getAppName").then((appName) => {

--- a/template/graphql/schema.ts
+++ b/template/graphql/schema.ts
@@ -7,6 +7,8 @@ import prettierConfig from '../prettier.config';
 
 import * as types from './modules';
 
+const currentDirectory = process.cwd();
+
 export const schema = makeSchema({
   types,
   plugins: [
@@ -15,24 +17,24 @@ export const schema = makeSchema({
       experimentalCRUD: true,
       outputs: {
         typegen: path.join(
-          __dirname,
-          '../node_modules/@types/typegen-nexus-plugin-prisma/index.d.ts'
+          currentDirectory,
+          'node_modules/@types/typegen-nexus-plugin-prisma/index.d.ts'
         ),
       },
     }),
   ],
   outputs: {
-    schema: path.join(__dirname, '../api.graphql'),
-    typegen: path.join(__dirname, '../node_modules/@types/nexus-typegen/index.d.ts'),
+    schema: path.join(currentDirectory, 'api.graphql'),
+    typegen: path.join(currentDirectory, 'node_modules/@types/nexus-typegen/index.d.ts'),
   },
   typegenAutoConfig: {
     sources: [
       {
-        source: path.join(__dirname, '../node_modules/.prisma/client/index.d.ts'),
+        source: path.join(currentDirectory, 'node_modules/.prisma/client/index.d.ts'),
         alias: 'db',
       },
       {
-        source: path.join(__dirname, './context.ts'),
+        source: path.join(currentDirectory, 'graphql', 'context.ts'),
         alias: 'ContextModule',
       },
     ],


### PR DESCRIPTION
There was a problem with the configuration for nexus schema typegen. Sometimes it would return the correct directory and others it would return `/`. This uses `path.cwd` for more consistency.


## Changes

- use path.cwd for typegen paths
- add e2e test to make sure that playground loads

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/14339/96189730-0eabd380-0f0f-11eb-94db-e34e0b02cf8d.png)

After:
![image](https://user-images.githubusercontent.com/14339/96190193-d35dd480-0f0f-11eb-9229-5b1ab3a027ec.png)

![image](https://user-images.githubusercontent.com/14339/96190411-364f6b80-0f10-11eb-865f-794d1633e7db.png)

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works
- [x] Deploying to Vercel still works (https://bison-versions-myr3ev0t1.vercel.app/)

Fixes #84 