### PR TITLE
fix(tests): ensure the generated tests pass

### DIFF
--- a/template/api.graphql
+++ b/template/api.graphql
@@ -25,11 +25,15 @@ input DateTimeFilter {
   equals: DateTime
   gt: DateTime
   gte: DateTime
-  in: [DateTime]
+  in: [DateTime!]
   lt: DateTime
   lte: DateTime
   not: NestedDateTimeFilter
-  notIn: [DateTime]
+  notIn: [DateTime!]
+}
+
+input EnumRoleNullableListFilter {
+  equals: [Role!]
 }
 
 """
@@ -55,11 +59,11 @@ input NestedDateTimeFilter {
   equals: DateTime
   gt: DateTime
   gte: DateTime
-  in: [DateTime]
+  in: [DateTime!]
   lt: DateTime
   lte: DateTime
   not: NestedDateTimeFilter
-  notIn: [DateTime]
+  notIn: [DateTime!]
 }
 
 input NestedStringFilter {
@@ -68,11 +72,11 @@ input NestedStringFilter {
   equals: String
   gt: String
   gte: String
-  in: [String]
+  in: [String!]
   lt: String
   lte: String
   not: NestedStringFilter
-  notIn: [String]
+  notIn: [String!]
   startsWith: String
 }
 
@@ -107,13 +111,13 @@ input ProfileCreateWithoutUserInput {
 }
 
 input ProfileWhereInput {
-  AND: [ProfileWhereInput]
+  AND: [ProfileWhereInput!]
   createdAt: DateTimeFilter
   firstName: StringFilter
   id: StringFilter
   lastName: StringFilter
-  NOT: [ProfileWhereInput]
-  OR: [ProfileWhereInput]
+  NOT: [ProfileWhereInput!]
+  OR: [ProfileWhereInput!]
   updatedAt: DateTimeFilter
   user: UserWhereInput
   userId: StringFilter
@@ -134,9 +138,14 @@ type Query {
     before: UserWhereUniqueInput
     first: Int
     last: Int
-    orderBy: [UserOrderByInput]
+    orderBy: [UserOrderByInput!]
     where: UserWhereInput
   ): [User!]!
+}
+
+enum QueryMode {
+  default
+  insensitive
 }
 
 enum Role {
@@ -161,11 +170,12 @@ input StringFilter {
   equals: String
   gt: String
   gte: String
-  in: [String]
+  in: [String!]
   lt: String
   lte: String
+  mode: QueryMode
   not: NestedStringFilter
-  notIn: [String]
+  notIn: [String!]
   startsWith: String
 }
 
@@ -192,7 +202,7 @@ input UserCreateInput {
 }
 
 input UserCreaterolesInput {
-  set: [Role]
+  set: [Role!]!
 }
 
 input UserOrderByInput {
@@ -205,15 +215,15 @@ input UserOrderByInput {
 }
 
 input UserWhereInput {
-  AND: [UserWhereInput]
+  AND: [UserWhereInput!]
   createdAt: DateTimeFilter
   email: StringFilter
   id: StringFilter
-  NOT: [UserWhereInput]
-  OR: [UserWhereInput]
+  NOT: [UserWhereInput!]
+  OR: [UserWhereInput!]
   password: StringFilter
   profile: ProfileWhereInput
-  roles: [Role]
+  roles: EnumRoleNullableListFilter
   updatedAt: DateTimeFilter
 }
 

--- a/template/graphql/context.ts
+++ b/template/graphql/context.ts
@@ -21,6 +21,7 @@ export async function createContext(context: ApolloApiContext): Promise<Context>
 
   return {
     db: prisma,
+    prisma,
     user,
   };
 }
@@ -29,5 +30,6 @@ type ApolloApiContext = ApolloContext<{ req: IncomingMessage }>;
 
 export type Context = {
   db: PrismaClient;
+  prisma: PrismaClient;
   user: User;
 };

--- a/template/tests/helpers.ts
+++ b/template/tests/helpers.ts
@@ -53,7 +53,7 @@ export const graphQLRequestAsUser = async (
 export const resetDB = async (): Promise<boolean> => {
   if (process.env.NODE_ENV === 'production') return Promise.resolve(false);
 
-  const match = process.env.DATABASE_URL.match(/schema=(\w*)(&.*)*$/);
+  const match = process.env.DATABASE_URL.match(/schema=(.*)(&.*)*$/);
   const schema = match ? match[1] : 'public';
 
   // NOTE: the prisma client does not handle this query well, use pg instead

--- a/template/tests/requests/user/login.test.ts
+++ b/template/tests/requests/user/login.test.ts
@@ -68,6 +68,26 @@ describe('login mutation', () => {
               },
             },
           },
+          "extensions": Object {
+            "cacheControl": Object {
+              "hints": Array [
+                Object {
+                  "maxAge": 0,
+                  "path": Array [
+                    "login",
+                  ],
+                },
+                Object {
+                  "maxAge": 0,
+                  "path": Array [
+                    "login",
+                    "user",
+                  ],
+                },
+              ],
+              "version": 1,
+            },
+          },
         }
       `);
     });

--- a/template/tests/requests/user/me.test.ts
+++ b/template/tests/requests/user/me.test.ts
@@ -18,12 +18,25 @@ describe('me query', () => {
       const response = await graphQLRequest({ query });
 
       expect(response.body).toMatchInlineSnapshot(`
-              Object {
-                "data": Object {
-                  "me": null,
+        Object {
+          "data": Object {
+            "me": null,
+          },
+          "extensions": Object {
+            "cacheControl": Object {
+              "hints": Array [
+                Object {
+                  "maxAge": 0,
+                  "path": Array [
+                    "me",
+                  ],
                 },
-              }
-          `);
+              ],
+              "version": 1,
+            },
+          },
+        }
+      `);
     });
   });
 
@@ -45,16 +58,29 @@ describe('me query', () => {
       const response = await graphQLRequestAsUser(user, { query });
 
       expect(response.body).toMatchInlineSnapshot(`
-          Object {
-            "data": Object {
-              "me": Object {
-                "email": "foo@wee.net",
-                "roles": Array [
-                  "USER",
-                ],
-              },
+        Object {
+          "data": Object {
+            "me": Object {
+              "email": "foo@wee.net",
+              "roles": Array [
+                "USER",
+              ],
             },
-          }
+          },
+          "extensions": Object {
+            "cacheControl": Object {
+              "hints": Array [
+                Object {
+                  "maxAge": 0,
+                  "path": Array [
+                    "me",
+                  ],
+                },
+              ],
+              "version": 1,
+            },
+          },
+        }
       `);
     });
   });

--- a/template/tests/requests/user/signup.test.ts
+++ b/template/tests/requests/user/signup.test.ts
@@ -56,7 +56,7 @@ describe('User signup mutation', () => {
 
       expect(errors).toMatchInlineSnapshot(`
         Array [
-          "Variable \\"$data\\" got invalid value { email: \\"hello@wee.net\\", password: \\"fake\\", roles: { set: [Array] } }; Field \\"roles\\" is not defined by type SignupInput.",
+          "Variable \\"$data\\" got invalid value { email: \\"hello@wee.net\\", password: \\"fake\\", roles: { set: [Array] } }; Field \\"roles\\" is not defined by type \\"SignupInput\\".",
         ]
       `);
     });


### PR DESCRIPTION
This fixes a few issues from #66 that were missed and caused tests in a newly generated app to fail.

## Changes

- regenerate `api.graphql` file
- adds `prisma` alias to context
- relaxes regex around test schema parsing to avoid database truncation errors
- updates snapshots to reflect error message and cache control updates

## Screenshots
![image](https://user-images.githubusercontent.com/14339/96527408-feb52c00-124d-11eb-8fb6-f9082385a6e6.png)

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works

Fixes #92 