### PR TITLE
fix(cli): fix create-bison-app on Node versions < 14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,10 @@
 name: Release
 on:
-  [push]
-  # we should always run tests
-  # push:
-  #   branches:
-  #     - main
-  #     - release
+  workflow_run:
+    workflows: ["Run Tests"]
+    branches: [main, canary]
+    types:
+      - completed
 
 jobs:
   release:
@@ -30,28 +29,6 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install packages
         run: yarn install --frozen-lockfile
-      - name: Create new App
-        id: create-app
-        # Sets outputs.appPath to the created directory
-        run: node ./scripts/createApp foo --acceptDefaults
-      - name: Check Build Command
-        run: |
-          cd ${{steps.create-app.outputs.appPath}}
-          yarn build
-      - name: Run Unit Tests
-        run: yarn test:unit
-      - name: Run Cypress E2E Tests
-        uses: cypress-io/github-action@v2
-        with:
-          start: node ./scripts/startServer ${{steps.create-app.outputs.appPath}} 3001
-          wait-on: "http://localhost:3001"
-          wait-on-timeout: 180
-          spec: cypress/integration/createBisonAppWithDefaults.test.js
-        env:
-          NODE_ENV: test
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APP_PATH: ${{steps.create-app.outputs.appPath}}
-          APP_NAME: ${{steps.create-app.outputs.appName}}
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,53 @@
+name: Run Tests
+on: [push]
+
+jobs:
+  release:
+    name: Run
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v2.1.1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Find yarn cache location
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: JS package cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install packages
+        run: yarn install --frozen-lockfile
+      - name: Create new App
+        id: create-app
+        # Sets outputs.appPath to the created directory
+        run: node ./scripts/createApp foo --acceptDefaults
+      - name: Check Build Command
+        run: |
+          cd ${{steps.create-app.outputs.appPath}}
+          yarn build
+      - name: Run Unit Tests
+        run: yarn test:unit
+      - name: Run Cypress E2E Tests
+        uses: cypress-io/github-action@v2
+        with:
+          start: node ./scripts/startServer ${{steps.create-app.outputs.appPath}} 3001
+          wait-on: "http://localhost:3001"
+          wait-on-timeout: 180
+          spec: cypress/integration/createBisonAppWithDefaults.test.js
+        env:
+          NODE_ENV: test
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APP_PATH: ${{steps.create-app.outputs.appPath}}
+          APP_NAME: ${{steps.create-app.outputs.appName}}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "bin": "cli.js",
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "scripts": {
     "semantic-release": "semantic-release",

--- a/template/.github/workflows/main.js.yml.ejs
+++ b/template/.github/workflows/main.js.yml.ejs
@@ -138,7 +138,7 @@ jobs:
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_email: ${{secrets.HEROKU_EMAIL}}
-          heroku_app_name: <%= host.staging?.name %>
+          heroku_app_name: <%= host.staging ? host.staging.name : '' %>
 <% } -%>
 
   deployProd:
@@ -166,5 +166,5 @@ jobs:
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_email: ${{secrets.HEROKU_EMAIL}}
-          heroku_app_name: <%= host.production?.name %>
+          heroku_app_name: <%= host.production ? host.production.name : '' %>
 <% } -%>


### PR DESCRIPTION
Prior to this, Node 14 was required due to the use of the optional chaining operator. This removes it and ensures tests run on multiple Node versions.

## Changes

- Remove use of optional chaining
- Split Github Actions into 2 workflows: test & release
- Add test matrix to ensure different node versions work


## Screenshots
![image](https://user-images.githubusercontent.com/14339/96583701-21c1f900-12ab-11eb-8567-6f50c65f3d2b.png)


## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works

Fixes #91