### PR TITLE
feat: add migrate on deploy and bison config to package.json

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -35,6 +35,23 @@ function generateQuestions(appName) {
       when: (answers) => answers.repo.addRemote,
     },
     {
+      name: "repo.stagingBranch",
+      type: "input",
+      message:
+        "What branch would you like to use for staging deploys? (migrates staging db on build)",
+      description: "The Staging Branch Name",
+      default: "dev",
+      when: (answers) => answers.repo.addRemote,
+    },
+    {
+      name: "repo.productionBranch",
+      type: "input",
+      message: "What branch would you like to use for production deploys?",
+      description: "The Production Branch Name",
+      default: "main",
+      when: (answers) => answers.repo.addRemote,
+    },
+    {
       name: "db.dev.name",
       type: "input",
       message: "What is the local database name?",

--- a/index.js
+++ b/index.js
@@ -7,12 +7,14 @@ const nodegit = require("nodegit");
 const ejs = require("ejs");
 const color = require("chalk");
 const { copyFiles } = require("./tasks/copyFiles");
+const { version: bisonVersion } = require("./package.json");
 
 module.exports = async ({ name, ...answers }) => {
   const pkgName = slugify(name);
   const targetFolder = path.join(process.cwd(), pkgName);
   const variables = {
     name: pkgName,
+    bisonVersion,
     ...answers,
   };
 

--- a/template/.github/workflows/main.js.yml.ejs
+++ b/template/.github/workflows/main.js.yml.ejs
@@ -118,9 +118,9 @@ jobs:
     ## For a traditional flow that auto-deploys staging and deploys prod is as needed, keep as is
   
 <% if (host.name === 'heroku') { -%>
-    if: github.ref == 'refs/heads/staging' 
+    if: github.ref == 'refs/heads/<%= repo.stagingBranch %>' 
 <% } else { -%>
-    if: github.ref != 'refs/heads/production' # every branch EXCEPT production
+    if: github.ref != 'refs/heads/<%= repo.productionBranch %>' # every branch EXCEPT production
 <% } -%>
     steps:
       - uses: actions/checkout@v2
@@ -148,7 +148,7 @@ jobs:
     needs: tests
     ## For a typical JAMstack flow, the ref below should be your default branch.
     ## For a traditional flow that auto-deploys staging and deploys prod is as needed, keep as is
-    if: github.ref == 'refs/heads/production'
+    if: github.ref == 'refs/heads/<%= repo.productionBranch %>'
     steps:
       - uses: actions/checkout@v2
 <% if (host.name === 'vercel') { -%>

--- a/template/package.json.ejs
+++ b/template/package.json.ejs
@@ -6,10 +6,10 @@
   "cacheDirectories": [".next/cache"],
 <% } -%>
   "scripts": {
-    "build": "yarn build:nexus && yarn build:prisma && yarn build:next",
+    "build": "ts-node ./scripts/buildProd",
     "build:prisma": "prisma generate",
     "build:next": "next build",
-    "build:nexus": "ts-node -P tsconfig.cjs.json --transpile-only graphql/schema.ts",
+    "build:nexus": "NODE_ENV=development ts-node -P tsconfig.cjs.json --transpile-only graphql/schema.ts",
     "cypress:run": "cypress run",
     "cypress:local": "CYPRESS_LOCAL=true CYPRESS_BASE_URL=http://localhost:3000 cypress",
     "db:migrate": "yarn -s prisma migrate up --experimental",
@@ -107,6 +107,13 @@
     "ts-node": "^8.10.2",
     "ts-node-dev": "^1.0.0-pre.63",
     "typescript": "^3.9.7"
+  },
+  "bison": {
+    "version": "<%= bisonVersion %>",
+    "branches": {
+      "staging": "<%= repo.stagingBranch %>",
+      "production": "<%= repo.productionBranch %>"
+    }
   },
   "husky": {
     "hooks": {

--- a/template/scripts/buildProd.ts
+++ b/template/scripts/buildProd.ts
@@ -1,0 +1,44 @@
+export {};
+const spawn = require('child_process').spawn;
+
+const bisonConfig = require('../package.json').bison;
+const DEFAULT_BUILD_COMMAND = `yarn build:nexus && yarn build:prisma && yarn build:next`;
+
+/**
+ * This builds the production app.
+ * if the current branch should be migrated, it runs migrations first.
+ */
+function buildProd() {
+  const { staging, production } = bisonConfig.branches;
+  const branchesToMigrate = new RegExp(`${staging}|${production}`);
+  const currentBranch = process.env.BRANCH || process.env.VERCEL_GITHUB_COMMIT_REF;
+  const shouldMigrate = branchesToMigrate.test(currentBranch);
+
+  console.log('--------------------------------------------------------------');
+  console.log('Determining if we should migrate the database...');
+  console.log('branches to migrate:', branchesToMigrate);
+  console.log('current branch name:', currentBranch || '(unknown)');
+  console.log(shouldMigrate ? `${currentBranch} detected. Migrating.` : `Not running migrations.`);
+  console.log('--------------------------------------------------------------');
+
+  let buildCommand = DEFAULT_BUILD_COMMAND;
+
+  if (shouldMigrate) {
+    buildCommand = `yarn db:migrate && ${buildCommand}`;
+  }
+
+  const child = spawn(buildCommand, {
+    shell: true,
+    stdio: 'inherit',
+  });
+
+  child.on('exit', function (code) {
+    process.exit(code);
+  });
+}
+
+if (require.main === module) {
+  buildProd();
+}
+
+module.exports = { buildProd };

--- a/test/tasks/copyFiles.test.js
+++ b/test/tasks/copyFiles.test.js
@@ -1,7 +1,9 @@
-const { makeTempDir } = require("../../utils/makeTempDir");
 const fs = require("fs");
 const path = require("path");
+
+const { makeTempDir } = require("../../utils/makeTempDir");
 const { copyFiles } = require("../../tasks/copyFiles");
+const { version: bisonVersion } = require("../../package.json");
 
 const DEFAULT_VARS = {
   host: {
@@ -19,6 +21,11 @@ const DEFAULT_VARS = {
       name: "testdb",
     },
   },
+  repo: {
+    stagingBranch: "dev",
+    productionBranch: "main",
+  },
+  bisonVersion,
 };
 
 describe("copyFiles", () => {
@@ -81,7 +88,6 @@ describe("copyFiles", () => {
         "cypress.json",
         "jest.config.js",
         "next-env.d.ts",
-        "package.json",
         "prettier.config.js",
         "README.md",
         "tsconfig.cjs.json",
@@ -94,6 +100,19 @@ describe("copyFiles", () => {
 
         expect(() => fs.statSync(filePath)).not.toThrowError();
       });
+    });
+
+    it("copies package.json with the expected content", async () => {
+      const filePath = path.join(targetFolder, "package.json");
+      const contents = require(filePath);
+      const { bison: bisonConfig } = contents;
+
+      expect(bisonConfig.version).toBe(bisonVersion);
+      expect(bisonConfig.branches.staging).toBe(variables.repo.stagingBranch);
+
+      expect(bisonConfig.branches.production).toBe(
+        variables.repo.productionBranch
+      );
     });
 
     it("copies pages", async () => {


### PR DESCRIPTION
This ensures that builds are migrated properly for branches we care about (the staging and prod branches)

In order to properly do this, we add a bison config to package.json. That stores:
* The version used to init the project
* the staging branch
* the production branch

Once we move to Lerna and have a separate Bison package, we wont need the version. But until that time it will be really helpful in helping users upgrade to the latest improvements.

## Changes

- add `buildProd` script which handles migrate & build
- ask users what branches to use for staging/production. This is to drive migrations for staging/prod databases, but also paves the way in the future to help handle branch merging or other branch based configurations.
- forces `build:nexus` to use `NODE_ENV=development`. This is a huge gotcha, but if `NODE_ENV` is set to production, it will not build types and thus will fail on CI.


## Screenshots
![image](https://user-images.githubusercontent.com/14339/96808146-479fe880-13e6-11eb-98ed-458d3d54c6a1.png)

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works