### PR TITLE
fix: ensure yarnWithEnv script properly exits

### DIFF
--- a/template/scripts/yarnWithEnv.ts
+++ b/template/scripts/yarnWithEnv.ts
@@ -3,4 +3,8 @@ const spawn = require('child_process').spawn;
 
 // Executes a yarn command in the context of a dotenv file
 const args = process.argv.slice(2);
-spawn('yarn', args, { stdio: 'inherit' });
+const child = spawn('yarn', args, { stdio: 'inherit' });
+
+child.on('exit', function (code) {
+  process.exit(code);
+});


### PR DESCRIPTION
If the child process failed, we previously ignored it.

## Changes

- ensure that we exit the process if the child process exits.


## Screenshots

(prefer animated gif)


## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works

Fixes #98 