### PR TITLE
fix: setup node action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Node
-        uses: actions/setup-node@v2.1.1
+        uses: actions/setup-node@v2.1.2
         with:
           node-version: ${{ matrix.node-version }}
       - name: Find yarn cache location

--- a/template/.github/workflows/main.js.yml.ejs
+++ b/template/.github/workflows/main.js.yml.ejs
@@ -32,7 +32,7 @@ jobs:
 
       # Node
       - name: Setup Node
-        uses: actions/setup-node@v2.1.1
+        uses: actions/setup-node@v2.1.2
         with:
           node-version: 14.6.0
 

--- a/template/_templates/cell/new/new.ejs
+++ b/template/_templates/cell/new/new.ejs
@@ -5,7 +5,7 @@ to: cells/<%= [h.inflection.camelize(h.dirName(name)), h.camelizedBaseName(name)
 <% component = h.camelizedBaseName(name) -%>
 import React from 'react';
 import gql from 'graphql-tag';
-import { Spinner, Text } from '@chakra-ui/core';
+import { Spinner, Text } from '@chakra-ui/react';
 
 import { useMyProfileQuery, MyProfileQuery } from '../types';
 

--- a/template/_templates/component/new/new.ejs
+++ b/template/_templates/component/new/new.ejs
@@ -4,7 +4,7 @@ to: components/<%= [h.inflection.camelize(h.dirName(name)), h.camelizedBaseName(
 <% formattedPath = h.camelizedPathName(name) -%>
 <% component = h.camelizedBaseName(name) -%>
 import React from 'react';
-import { Heading, Center } from '@chakra-ui/core';
+import { Heading, Center } from '@chakra-ui/react';
 
 /** Description of component */
 export function <%= component %>() {

--- a/template/_templates/page/new/new.ejs
+++ b/template/_templates/page/new/new.ejs
@@ -6,7 +6,7 @@ to: pages/<%= name %>.tsx
 <% base = h.camelizedBaseName(name) -%>
 import React from 'react';
 import Head from 'next/head';
-import { Heading, Center, Flex } from '@chakra-ui/core';
+import { Heading, Center, Flex } from '@chakra-ui/react';
 
 function <%= pageName %>() {
   return (

--- a/template/components/AllProviders.tsx
+++ b/template/components/AllProviders.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ChakraProvider, CSSReset } from '@chakra-ui/core';
+import { ChakraProvider, CSSReset } from '@chakra-ui/react';
 import { ApolloProvider } from '@apollo/client';
 
 import { AuthProvider } from '../context/auth';

--- a/template/components/CenteredBoxForm.tsx
+++ b/template/components/CenteredBoxForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box } from '@chakra-ui/core';
+import { Box } from '@chakra-ui/react';
 
 /** A form with a centered box. Ex: Login, Signup */
 export function CenteredBoxForm({ children }) {

--- a/template/components/ErrorText.tsx
+++ b/template/components/ErrorText.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, TextProps } from '@chakra-ui/core';
+import { Text, TextProps } from '@chakra-ui/react';
 
 /** Renders error text under form inputs */
 export function ErrorText({ children, ...textProps }: TextProps) {

--- a/template/components/FullPageSpinner.tsx
+++ b/template/components/FullPageSpinner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Spinner, Center } from '@chakra-ui/core';
+import { Spinner, Center } from '@chakra-ui/react';
 
 /** Renders a full page loading spinner */
 export function FullPageSpinner() {

--- a/template/components/LoginForm.tsx
+++ b/template/components/LoginForm.tsx
@@ -11,7 +11,7 @@ import {
   Stack,
   Button,
   Circle,
-} from '@chakra-ui/core';
+} from '@chakra-ui/react';
 import { useForm } from 'react-hook-form';
 import { gql } from '@apollo/client';
 

--- a/template/components/Logo.tsx
+++ b/template/components/Logo.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Heading } from '@chakra-ui/core';
+import { Heading } from '@chakra-ui/react';
 import NextLink from 'next/link';
 
 export function Logo() {

--- a/template/components/Nav.tsx
+++ b/template/components/Nav.tsx
@@ -8,7 +8,7 @@ import {
   Menu,
   MenuList,
   MenuItem,
-} from '@chakra-ui/core';
+} from '@chakra-ui/react';
 import NextLink from 'next/link';
 
 export function Nav() {

--- a/template/components/SignupForm.tsx
+++ b/template/components/SignupForm.tsx
@@ -10,7 +10,7 @@ import {
   Stack,
   Button,
   Circle,
-} from '@chakra-ui/core';
+} from '@chakra-ui/react';
 import { gql } from '@apollo/client';
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/router';

--- a/template/layouts/LoggedIn.tsx
+++ b/template/layouts/LoggedIn.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useRouter } from 'next/router';
-import { Box, Center, Flex, Text, Button } from '@chakra-ui/core';
+import { Box, Center, Flex, Text, Button } from '@chakra-ui/react';
 
 import { Logo } from '../components/Logo';
 import { Nav } from '../components/Nav';

--- a/template/layouts/LoggedOut.tsx
+++ b/template/layouts/LoggedOut.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Center, Flex, Text, Button } from '@chakra-ui/core';
+import { Box, Center, Flex, Text, Button } from '@chakra-ui/react';
 import NextLink from 'next/link';
 
 import { Logo } from '../components/Logo';

--- a/template/package.json.ejs
+++ b/template/package.json.ejs
@@ -41,9 +41,9 @@
   },
   "dependencies": {
     "@apollo/client": "^3.0.2",
-    "@chakra-ui/core": "^1.0.0-rc.0",
-    "@chakra-ui/theme": "^1.0.0-rc.0",
-    "@chakra-ui/theme-tools": "^1.0.0-rc.0",
+    "@chakra-ui/react": "^1.0.0",
+    "@chakra-ui/theme": "^1.0.0",
+    "@chakra-ui/theme-tools": "^1.0.0",
     "@nexus/schema": "^0.16.0",
     "@prisma/client": "2.8.1",
 <% if (host.name === 'vercel') { -%>
@@ -54,6 +54,9 @@
 <% } -%>
     "bcryptjs": "^2.4.3",
     "cross-fetch": "^3.0.5",
+    "@emotion/react": "^11.0.0",
+    "@emotion/styled": "^11.0.0",
+    "framer-motion": "^2.9.4",
     "graphql": "^15.3.0",
     "graphql-scalars": "^1.3.0",
     "graphql-type-json": "^0.3.1",

--- a/template/pages/index.tsx
+++ b/template/pages/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Head from 'next/head';
-import { Heading, Center } from '@chakra-ui/core';
+import { Heading, Center } from '@chakra-ui/react';
 
 function Home() {
   return (


### PR DESCRIPTION
This PR bumps `actions/setup-node` to version `2.1.2` to address the deprecated `set-env` capability with git actions.

## Changes

- Bump version actions/setup-node in the template for main.yml workflow
- Bump version for tests workflow same as above


## Screenshots




## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works
