### PR TITLE
docs: Change all uses of JAMstack to Jamstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center" style="text-align:center">
   <img alt="Bison Logo" src="https://user-images.githubusercontent.com/14339/89243835-f47e7c80-d5d2-11ea-8d8d-36202227d0ec.png" />
-  <h1 align="center">The Full Stack JAMstack in-a-box.</h1>
+  <h1 align="center">The Full Stack Jamstack in-a-box.</h1>
 </p>
 
 Bison is a starter repository created out of real-world apps at [Echobind](https://echobind.com). It represents our team's "Greenfield Web Stack" that we use when creating web apps for clients.
@@ -41,7 +41,7 @@ We're always improving on this, and we welcome suggestions from the community!
 
 ## Alternatives
 
-A few other projects that are rapidly maturing in the Full Stack JAMStack space.
+A few other projects that are rapidly maturing in the Full Stack Jamstack space.
 
 **RedwoodJS**
 [Redwood](https://github.com/redwoodjs/redwood) is a very promising framework that we're watching. We took the concept of "Cells" directly from Redwood (though admittedly our version takes a bit more code!)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -14,10 +14,10 @@ The Vercel project and org id, can be copied from `.vercel/project.json`. You ca
 
 After tests pass, the app will deploy. Every push will create a preview deployment. Merging to the main branch will deploy to staging, and pushing to the production branch will deploy to production.
 
-If you'd like to change these configurations to a more typical JAMstack flow (where merging to the main branch deploys to production), update the section below in `..github/workflows/main.js.yml`:
+If you'd like to change these configurations to a more typical Jamstack flow (where merging to the main branch deploys to production), update the section below in `..github/workflows/main.js.yml`:
 
 ```
-## For a typical JAMstack flow, this should be your default branch.
+## For a typical Jamstack flow, this should be your default branch.
 ## For a traditional flow that auto-deploys staging and deploys prod is as needed, keep as is
 if: github.ref != 'refs/heads/production' # every branch EXCEPT production
 ```

--- a/packages/create-bison-app/logo.js
+++ b/packages/create-bison-app/logo.js
@@ -13,6 +13,6 @@ module.exports = `
 @@@@@@%@@@@@@&%%%%%%%%&&&@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@&&&%%%%%%%%&@@@@@@%%@@@@@
 @@@@@@%%%%@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@%%%%%@@@@@
 
-        The Full Stack JAMstack in-a-box. Make something awesome with it!
+        The Full Stack Jamstack in-a-box. Make something awesome with it!
                                    ♥️  Echobind
 `;

--- a/packages/create-bison-app/package.json
+++ b/packages/create-bison-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-bison-app",
   "version": "1.9.14-canary.2",
-  "description": "Creates a production-ready full-stack JAMstack app",
+  "description": "Creates a production-ready full-stack Jamstack app",
   "license": "MIT",
   "repository": "echobind/bisonapp",
   "author": {

--- a/packages/create-bison-app/template/.github/workflows/main.js.yml.ejs
+++ b/packages/create-bison-app/template/.github/workflows/main.js.yml.ejs
@@ -114,7 +114,7 @@ jobs:
     # needs: tests
 <% } -%>
 
-    ## For a typical JAMstack flow, the ref below should be your default branch.
+    ## For a typical Jamstack flow, the ref below should be your default branch.
     ## For a traditional flow that auto-deploys staging and deploys prod is as needed, keep as is
   
 <% if (host.name === 'heroku') { -%>
@@ -146,7 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     # For production deploys, make sure tests pass first
     needs: tests
-    ## For a typical JAMstack flow, the ref below should be your default branch.
+    ## For a typical Jamstack flow, the ref below should be your default branch.
     ## For a traditional flow that auto-deploys staging and deploys prod is as needed, keep as is
     if: github.ref == 'refs/heads/<%= repo.productionBranch %>'
     steps:


### PR DESCRIPTION
## Changes

JAMstack -> Jamstack

## Screenshots

![Screen Shot 2020-12-11 at 4 34 45 PM](https://user-images.githubusercontent.com/12433465/101964672-5e391380-3bcf-11eb-8af4-3dc3ccda0791.jpg)

## Checklist

- [ ] Requires dependency update?
- [ ] Generating a new app works

## Fixes

In [December of last year](https://github.com/jamstack/jamstack.org/commit/41c0b767694c1f8c7e3fabcb1e0d770b154c00d7) Netlify made a slight modification to the Jamstack brand that they have cultivated and removed the all uppercase JAM.

<img width="602" alt="Jamstack_Logo_DarkBG_Solid" src="https://user-images.githubusercontent.com/12433465/101964633-39dd3700-3bcf-11eb-86bd-7c4f48947176.png">

Here's Chris Coyier's take on it: [JAMstack vs. Jamstack](https://css-tricks.com/jamstack-vs-jamstack/). For me, the reasoning I would switch this Bison repo specifically doesn't really have anything to do with the argument about the acronym.

It's more so that I just think it's been long enough to definitively say it's not gonna change back. But if you want to keep it the way it is and go old school then more power to you! And I'd also change Full Stack to Fullstack, just cause Fullstack Jamstack looks so much cleaner to me. But that's just me.