### PR TITLE
ci: use the head_branch property of the workflow_run event 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,14 +38,16 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install packages
         run: yarn && yarn lerna bootstrap
+      - name: Log workflow event
+        run: echo "${{ toJSON(github.event.workflow_run) }}"
       - name: Release Canary
-        if: github.ref == 'refs/heads/canary'
+        if: github.event.workflow_run.head_branch == 'canary'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: yarn publish:canary
       - name: Release Latest
-        if: github.ref == 'refs/heads/main'
+        if: github.event.workflow_run.head_branch == 'main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   workflow_run:
     workflows: ["Run Tests"]
-    branches: [main, canary]
+    branches: [main, canary, fix-gh-action-release]
     types:
       - completed
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,6 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install packages
         run: yarn && yarn lerna bootstrap
-      - name: Log workflow event
-        run: echo "${{ toJSON(github.event.workflow_run) }}"
       - name: Release Canary
         if: github.event.workflow_run.head_branch == 'canary'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   workflow_run:
     workflows: ["Run Tests"]
-    branches: [main, canary, fix-gh-action-release]
+    branches: [main, canary]
     types:
       - completed
 


### PR DESCRIPTION
This should fix the Release workflow when running on the main branch. Unfortunately I have no way to fully test until it is merged.

## Changes
- use `github.event.workflow_run.head_branch` instead of `github.ref`


## Screenshots

n/a


## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works

Fixes #120