### PR TITLE
fix: the prisma .env template was missing a colon between the username and password for the postgres url

### DIFF
--- a/packages/create-bison-app/template/prisma/_.env.ejs
+++ b/packages/create-bison-app/template/prisma/_.env.ejs
@@ -4,4 +4,4 @@
 # Prisma supports the native connection string format for PostgreSQL, MySQL and SQLite.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-DATABASE_URL="postgresql://<%= db.dev.user %><%= db.dev.password %>@<%= db.dev.host %>:<%= db.dev.port %>/<%= db.dev.name %>?schema=public"
+DATABASE_URL="postgresql://<%= db.dev.user %>:<%= db.dev.password %>@<%= db.dev.host %>:<%= db.dev.port %>/<%= db.dev.name %>?schema=public"

--- a/packages/create-bison-app/template/prisma/_.env.ejs
+++ b/packages/create-bison-app/template/prisma/_.env.ejs
@@ -4,4 +4,4 @@
 # Prisma supports the native connection string format for PostgreSQL, MySQL and SQLite.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-DATABASE_URL="postgresql://<%= db.dev.user %>:<%= db.dev.password %>@<%= db.dev.host %>:<%= db.dev.port %>/<%= db.dev.name %>?schema=public"
+DATABASE_URL="postgresql://<%= db.dev.user %><% if (db.dev.password) { %>:<%= db.dev.password %><% } %>@<%= db.dev.host %>:<%= db.dev.port %>/<%= db.dev.name %>?schema=public"

--- a/packages/create-bison-app/test/tasks/copyFiles.test.js
+++ b/packages/create-bison-app/test/tasks/copyFiles.test.js
@@ -147,7 +147,7 @@ describe("copyFiles", () => {
       const fileString = file.toString();
       const { user, password, host, port, name } = variables.db.dev;
 
-      const databaseUrl = `postgresql://${user}${password}@${host}:${port}`;
+      const databaseUrl = `postgresql://${user}:${password}@${host}:${port}`;
 
       expect(fileString).toContain(databaseUrl);
       expect(fileString).toContain(name);

--- a/packages/create-bison-app/test/tasks/copyFiles.test.js
+++ b/packages/create-bison-app/test/tasks/copyFiles.test.js
@@ -147,7 +147,7 @@ describe("copyFiles", () => {
       const fileString = file.toString();
       const { user, password, host, port, name } = variables.db.dev;
 
-      const databaseUrl = `postgresql://${user}:${password}@${host}:${port}`;
+      const databaseUrl = `postgresql://${user}${password}@${host}:${port}`;
 
       expect(fileString).toContain(databaseUrl);
       expect(fileString).toContain(name);


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

When I ran `npx create-bison-app MyApp` on my local machine, I initialized the database with:
username: postgres
password: docker

But when I ran `yarn db:setup` I got the following error.
```
❯ yarn db:setup
yarn run v1.22.10
$ yarn db:migrate && yarn prisma generate
$ yarn -s prisma migrate up --experimental && yarn build:prisma
Environment variables loaded from prisma/.env
Prisma Schema loaded from prisma/schema.prisma
Error: P1000: Authentication failed against database server at `localhost`, the provided database credentials for `postgresdocker` are not valid.

Please make sure to provide valid database credentials for the database server at `localhost`.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

It looks like there is just a small colon missing from the template.

## Screenshots

(prefer animated gif)


## Checklist

- [ ] Requires dependency update?
- [ ] Generating a new app works

Fixes #xxx
