### PR TITLE
feat: expose common scalars from graphql-scalars

### DIFF
--- a/packages/create-bison-app/template/graphql/modules/scalars.ts
+++ b/packages/create-bison-app/template/graphql/modules/scalars.ts
@@ -1,5 +1,14 @@
-import { DateTimeResolver, JSONObjectResolver } from 'graphql-scalars';
+import {
+  DateTimeResolver,
+  EmailAddressResolver,
+  JSONObjectResolver,
+  PhoneNumberResolver,
+  URLResolver,
+} from 'graphql-scalars';
 import { asNexusMethod } from 'nexus';
 
-export const jsonScalar = asNexusMethod(JSONObjectResolver, 'json');
-export const dateTimeScalar = asNexusMethod(DateTimeResolver, 'date');
+export const JSON = asNexusMethod(JSONObjectResolver, 'json');
+export const DateTime = asNexusMethod(DateTimeResolver, 'date');
+export const Email = asNexusMethod(EmailAddressResolver, 'email');
+export const PhoneNumber = asNexusMethod(PhoneNumberResolver, 'phone');
+export const URL = asNexusMethod(URLResolver, 'url');


### PR DESCRIPTION
This exposes the most commonly used ones.

Example usage: 

```ts
t.email('emailField')
t.phone('phoneField')
```

## Changes

- adds email, phone, url scalars. 


## Screenshots

n/a

## Checklist

- [ ] Requires dependency update?
- [ ] Generating a new app works

Fixes #xxx
