### PR TITLE
Replace unsupported prisma command

### DIFF
--- a/packages/create-bison-app/template/tests/helpers.ts
+++ b/packages/create-bison-app/template/tests/helpers.ts
@@ -85,7 +85,7 @@ export const resetDB = async (): Promise<boolean> => {
  */
 export const setupDB = async (): Promise<boolean> => {
   // ensure the db is created and migrated
-  await exec(`yarn prisma migrate up --create-db --experimental`);
+  await exec(`yarn prisma migrate deploy`);
 
   return true;
 };

--- a/packages/create-bison-app/template/tests/helpers.ts
+++ b/packages/create-bison-app/template/tests/helpers.ts
@@ -5,7 +5,7 @@ import request from 'supertest';
 import { User } from '@prisma/client';
 import { Client } from 'pg';
 
-import { server, GRAPHQL_PATH } from '../pages/api/graphql';
+import server, { GRAPHQL_PATH } from '../pages/api/graphql';
 import { appJwtForUser } from '../services/auth';
 import { prisma, connect, disconnect } from '../lib/prisma';
 

--- a/packages/create-bison-app/template/tests/jest.setup.js.ejs
+++ b/packages/create-bison-app/template/tests/jest.setup.js.ejs
@@ -26,5 +26,5 @@ module.exports = async () => {
   global.process.env.DATABASE_URL = global.databaseUrl;
 
   // Run the migrations to ensure our schema has the required structure
-  await exec(`yarn prisma migrate up --create-db --experimental`);
+  await exec(`yarn prisma migrate deploy`);
 };


### PR DESCRIPTION
## Changes

The `migrate up` command no longer exists in our version of prisma. This changes to use the `migrate deploy` command.

After making this change and being able to run tests, I noticed the tests are failing. I started fixing them but this required a lot of changes. The main reason for this is because some of the generated files (GraphQL typings) are outdated. I'll get the tests passing in #154.

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works

Fixes #157 
