### PR TITLE
chore: upgrade react-hook-form

### DIFF
--- a/packages/create-bison-app/template/README.md.ejs
+++ b/packages/create-bison-app/template/README.md.ejs
@@ -237,7 +237,7 @@ export function OrganizationForm() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <input name="name" ref={register({ required: true })} />
+      <input {...register('name', { required: true })} />
       {errors.name && <span>This field is required</span>}
       
       <input type="submit" />
@@ -255,8 +255,7 @@ export function OrganizationForm() {
         <FormLabel htmlFor="name">Name</FormLabel>
         <Input
           type="text"
-          name="name"
-          ref={register({ required: true })}
+          {...register('name', { required: true })}
           isInvalid={errors.name}
         />
         <ErrorText>{errors.name && errors.name.message}</ErrorText>

--- a/packages/create-bison-app/template/components/LoginForm.tsx
+++ b/packages/create-bison-app/template/components/LoginForm.tsx
@@ -31,7 +31,13 @@ export const LOGIN_MUTATION = gql`
 
 /** Form to Login */
 export function LoginForm() {
-  const { register, handleSubmit, errors, setError } = useForm();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setError,
+  } = useForm();
+
   const [isLoading, setIsLoading] = useState(false);
   const [login] = useLoginMutation();
   const { login: loginUser } = useAuth();
@@ -68,8 +74,7 @@ export function LoginForm() {
           <FormLabel htmlFor="email">Email address</FormLabel>
           <Input
             type="text"
-            name="email"
-            ref={register({
+            {...register('email', {
               required: 'email is required',
               pattern: {
                 value: EMAIL_REGEX,
@@ -85,8 +90,7 @@ export function LoginForm() {
           <FormLabel htmlFor="password">Password</FormLabel>
           <Input
             type="password"
-            name="password"
-            ref={register({ required: 'password is required' })}
+            {...register('password', { required: 'password is required' })}
             isInvalid={errors.password}
           />
           <ErrorText>{errors.password && errors.password.message}</ErrorText>

--- a/packages/create-bison-app/template/components/SignupForm.tsx
+++ b/packages/create-bison-app/template/components/SignupForm.tsx
@@ -35,7 +35,13 @@ export const SIGNUP_MUTATION = gql`
 
 /** Form to sign up */
 export function SignupForm() {
-  const { register, handleSubmit, errors, setError } = useForm();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setError,
+  } = useForm();
+
   const [isLoading, setIsLoading] = useState(false);
   const [signup] = useSignupMutation();
   const { login } = useAuth();
@@ -77,8 +83,7 @@ export function SignupForm() {
           <FormLabel htmlFor="email">Email address</FormLabel>
           <Input
             type="text"
-            name="email"
-            ref={register({
+            {...register('email', {
               required: 'email is required',
               pattern: {
                 value: EMAIL_REGEX,
@@ -94,8 +99,7 @@ export function SignupForm() {
           <FormLabel htmlFor="password">Password</FormLabel>
           <Input
             type="password"
-            name="password"
-            ref={register({ required: 'password is required', minLength: 8 })}
+            {...register('password', { required: 'password is required', minLength: 8 })}
             isInvalid={errors.password}
           />
           <ErrorText>{errors.password && errors.password.message}</ErrorText>
@@ -105,8 +109,7 @@ export function SignupForm() {
           <FormLabel>First Name</FormLabel>
           <Input
             type="text"
-            name="firstName"
-            ref={register({ required: true })}
+            {...register('firstName', { required: true })}
             isInvalid={errors.firstName}
           />
           <ErrorText>{errors.firstName && errors.firstName.message}</ErrorText>
@@ -116,8 +119,7 @@ export function SignupForm() {
           <FormLabel>Last Name</FormLabel>
           <Input
             type="text"
-            name="lastName"
-            ref={register({ required: true })}
+            {...register('lastName', { required: true })}
             isInvalid={errors.lastName}
           />
           <ErrorText>{errors.lastName && errors.lastName.message}</ErrorText>

--- a/packages/create-bison-app/template/package.json.ejs
+++ b/packages/create-bison-app/template/package.json.ejs
@@ -65,7 +65,7 @@
     "nexus": "^1.0.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-hook-form": "^6.1.0",
+    "react-hook-form": "^7.8.8",
     "universal-cookie": "^4.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This upgrade ours `react-hook-form` to the latest version.

## Changes

- There were a couple breaking changes: https://github.com/react-hook-form/react-hook-form/blob/master/CHANGELOG.md#changes-16
  -  `register` now has to spread as props
  -  `errors` alias has been removed and now has to be accessed through `formState`

## Checklist

- [x] Requires dependency update?
- [x] Generating a new app works

Fixes #159 
