### PR TITLE
feat: add dev server that will live reload on template changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@ yarn-error.log*
 tmp
 lerna-debug.log
 .env
+
+packages/create-bison-app/dist/
+
+# symlinked files in the template directory for development
+packages/create-bison-app/template/types
+packages/create-bison-app/template/api.graphql
+packages/create-bison-app/template/types.ts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to Bison
+
+We would love for you to contribute to Bison and help make it even better than it is today!
+
+## Getting Started
+
+### Found a Bug?
+
+If you find a bug, you can help us by [submitting an issue](#submitting-an-issue) to our GitHub Repository. Even better, you can submit a [pull request](#submitting-a-pull-request) with a fix.
+
+### Development Workflow
+
+Refer to our individual package contributing guides for information about the developer workflow to contribute changes:
+
+- [create-bison-app](packages/create-bison-app/CONTRIBUTING.md)
+
+## Submitting an Issue
+
+Before you submit an issue, please search the [issue tracker](https://github.com/echobind/bisonapp/issues), maybe an issue for your problem already exists.
+
+When reporting bugs, please provide minimal reproduction steps and information about your development environment so maintainers can quickly replicate and fix the bug.
+
+When requesting features or enhancements, please provide your use-case so we can understand what you're trying to achieve.
+
+## Submitting a Pull Request
+
+Please provide all information in our pull request template when submitting a PR:
+- Description of the issue being fixed
+- Description of changes being made in the PR
+- Screenshots, preferably animated gif if making UI changes
+- Checklist
+  -  Does this update a dependency?
+  -  Verify that generating a new app works
+- Issue number
+
+## Commit Message Format
+
+We use conventional commit messages:
+
+```
+<type>(<scope>): <short summary>
+```
+
+The `<type>` and `<summary>` fields are mandatory, the `(<scope>)` field is optional.
+
+### Type
+
+Must be one of the following:
+
+* **build**: Changes that affect the build system or external dependencies
+* **chore**: Changes that don't modify src or test files
+* **ci**: Changes to our CI configuration files and scripts
+* **docs**: Documentation only changes
+* **feat**: A new feature
+* **fix**: A bug fix
+* **perf**: A code change that improves performance
+* **refactor**: A code change that neither fixes a bug nor adds a feature
+* **test**: Adding missing tests or correcting existing tests

--- a/packages/create-bison-app/CONTRIBUTING.md
+++ b/packages/create-bison-app/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing to create-bison-app
+
+## Getting Started
+
+Run the following commands in the `packages/create-bison-app` directory to start the development server:
+
+1. Run `yarn install` to install dependencies
+1. Run `yarn dev` to create a Bison app and start the server. Optionally, you may pass the following arguments:
+   - `--acceptDefaults` Skip interactive prompts and use default options to create a new Bison app
+   - `--clean` When running `yarn dev` subsequent times, use this to reconfigure and create a new Bison app
+   - `--port` Specify the port to listen on. Defaults to 3001.
+
+Example:
+```
+yarn dev --acceptDefaults --clean --port=5000
+```
+
+## Making Changes to the Bison Template
+
+After you have the development server running, you can make your changes in the `packages/create-bison-app/template/` directory which will trigger the server to recompile.

--- a/packages/create-bison-app/package.json
+++ b/packages/create-bison-app/package.json
@@ -14,6 +14,7 @@
     "node": ">=12"
   },
   "scripts": {
+    "dev": "node ./scripts/createDevAppAndStartServer",
     "test:e2e": "start-server-and-test 'node ./scripts/createAppAndStartServer foo --acceptDefaults' 3001 'cypress run --spec cypress/integration/createBisonAppWithDefaults.test.js'",
     "test:unit": "yarn jest",
     "test": "yarn test:unit"
@@ -45,6 +46,7 @@
   },
   "devDependencies": {
     "@actions/core": "1.2.6",
+    "chokidar": "^3.5.2",
     "cypress": "^5.1.0",
     "ejs-lint": "^1.1.0",
     "jest": "^26.4.2",
@@ -55,7 +57,8 @@
     "testPathIgnorePatterns": [
       "node_modules",
       "cypress",
-      "template"
+      "template",
+      "dist"
     ]
   },
   "gitHead": "691f39be2afe2beec5fed06acecc6bf1b36c54ac"

--- a/packages/create-bison-app/scripts/createApp.js
+++ b/packages/create-bison-app/scripts/createApp.js
@@ -10,8 +10,8 @@ async function init() {
   return await createApp(args);
 }
 
-async function createApp(args) {
-  const tmpdir = await makeTempDir();
+async function createApp(args, appDir) {
+  const tmpdir = appDir || await makeTempDir();
   const cliPath = path.join(__dirname, "..", "cli.js");
 
   const cliOptions = args.length ? args : ["myapp", "--acceptDefaults"];

--- a/packages/create-bison-app/scripts/createDevAppAndStartServer.js
+++ b/packages/create-bison-app/scripts/createDevAppAndStartServer.js
@@ -1,0 +1,107 @@
+const chokidar = require("chokidar");
+const execa = require("execa");
+const fs = require("fs");
+const path = require("path");
+const yargs = require("yargs/yargs");
+const { createApp } = require("../scripts/createApp");
+const { startServer } = require("../scripts/startServer");
+const { templateFolder } = require("../tasks/copyFiles");
+const { cleanTemplateDestPath } = require("../utils/copyDirectoryWithTemplate");
+const { copyWithTemplate } = require("../utils/copyWithTemplate");
+
+const BISON_DEV_APP_NAME = "bison-dev-app";
+const BISON_DEV_APP_VARIABLES_FILE = "bison.json";
+
+async function init() {
+  const distPath = path.join(__dirname, "..", "dist");
+  const devAppPath = path.join(distPath, BISON_DEV_APP_NAME);
+  const args = process.argv.slice(2);
+  const { clean, port } = yargs(args).argv;
+
+  if (clean) {
+    await fs.promises.rmdir(devAppPath, { recursive: true });
+    await removeTemplateSymlinks();
+  }
+
+  // Create bison app if it does not exist
+  if (!fs.existsSync(devAppPath)) {
+    if (!fs.existsSync(distPath)) {
+      await fs.promises.mkdir(distPath);
+    }
+
+    await createApp([BISON_DEV_APP_NAME, ...args], distPath);
+
+    await execa("yarn db:setup && yarn generate", {
+      cwd: devAppPath,
+      shell: true,
+      stdio: "inherit",
+    });
+
+    await createTemplateSymlinks(devAppPath);
+  }
+
+  const templateVariables = require(path.join(devAppPath, BISON_DEV_APP_VARIABLES_FILE));
+
+  const copyFile = async src => {
+    const relativeSrc = cleanTemplateDestPath(src.replace(templateFolder, ""));
+    const dest = path.join(devAppPath, relativeSrc);
+    if (src.match(/\.ejs$/) && !src.match(/_templates\//)) {
+      await copyWithTemplate(src, dest, templateVariables);
+    } else {
+      await fs.promises.copyFile(src, dest);
+    }
+  };
+
+  // Watch template files and copy to dev app
+  chokidar.watch(templateFolder, {
+      ignored: path => path.includes("node_modules")
+    })
+    .on("add", copyFile)
+    .on("change", copyFile);
+  
+  return startServer(devAppPath, port);
+}
+
+/**
+ * Create symbolic links to node_modules and generated files in the dev app so 
+ * the template directory files won't contain errors
+ */
+async function createTemplateSymlinks(appPath) {
+  // Files and directories that do not exist in template that need to be linked
+  const relativeAppPaths = ["api.graphql", "node_modules", "types", "types.ts"]
+
+  for (const relativePath of relativeAppPaths) {
+    await fs.promises.symlink(
+      path.join(appPath, relativePath), 
+      path.join(templateFolder, relativePath)
+    );
+  }
+}
+
+/**
+ * Remove all symlinks in the template directory
+ */
+async function removeTemplateSymlinks() {
+  const templatePath = relativePath => path.join(templateFolder, relativePath);
+  const unlinkFile = async filename => {
+    const filePath = templatePath(filename);
+    if (fs.existsSync(filePath) && fs.lstatSync(filePath).isSymbolicLink()) {
+      await fs.promises.unlink(filePath);
+    }
+  }
+
+  await unlinkFile("api.graphql");
+  await unlinkFile("types.ts");
+
+  // Directories cannot be "unlinked" so they must be removed
+  await fs.promises.rmdir(templatePath("node_modules"), { recursive: true });
+  await fs.promises.rmdir(templatePath("types"), { recursive: true });
+}
+
+if (require.main === module) {
+  init();
+}
+
+module.exports = {
+  BISON_DEV_APP_VARIABLES_FILE,
+};

--- a/packages/create-bison-app/tasks/copyFiles.js
+++ b/packages/create-bison-app/tasks/copyFiles.js
@@ -113,4 +113,5 @@ async function copyFiles({ variables, targetFolder }) {
 
 module.exports = {
   copyFiles,
+  templateFolder,
 };

--- a/packages/create-bison-app/utils/copyDirectoryWithTemplate.js
+++ b/packages/create-bison-app/utils/copyDirectoryWithTemplate.js
@@ -4,6 +4,16 @@ const globby = require("globby");
 const { copyWithTemplate } = require("./copyWithTemplate");
 
 /**
+ * Remove any extra prefix or extension from the template filename
+ * @param {*} file File path
+ */
+function cleanTemplateDestPath(file) {
+  return file
+    .replace(/_\./, ".")
+    .replace(/\.ejs$/, "");
+}
+
+/**
  * Copies a file to a different location, running it through an optional ejs template
  * @param {*} from The source file
  * @param {*} to The path to write
@@ -20,16 +30,13 @@ async function copyDirectoryWithTemplate(from, to, variables) {
 
   return await Promise.all(
     files.map(async (file) => {
-      const toFile = file
-        .replace(from, to)
-        .replace(/_\./, ".")
-        .replace(/\.ejs$/, "");
-
+      const toFile = cleanTemplateDestPath(file.replace(from, to));
       return copyWithTemplate(file, toFile, variables);
     })
   );
 }
 
 module.exports = {
+  cleanTemplateDestPath,
   copyDirectoryWithTemplate,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,6 +1787,14 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+anymatch@~3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
+  integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -2038,6 +2046,11 @@ before-after-hook@^2.0.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
   integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
 
+binary-extensions@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
+  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
 bl@^1.0.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.3.tgz#1e8dd80142eac80d7158c9dccc047fb620e035e7"
@@ -2080,7 +2093,7 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@^3.0.1:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -2338,6 +2351,21 @@ check-more-types@2.24.0, check-more-types@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
   integrity sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=
+
+chokidar@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
+  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 chownr@^1.0.1, chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.4"
@@ -3814,6 +3842,11 @@ fsevents@^2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
+fsevents@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -3973,6 +4006,13 @@ glob-parent@^5.0.0, glob-parent@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+  dependencies:
+    is-glob "^4.0.1"
+
+glob-parent@~5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
@@ -4422,6 +4462,13 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -4537,7 +4584,7 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -6095,7 +6142,7 @@ normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
-normalize-path@^3.0.0:
+normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -6967,6 +7014,13 @@ readdir-scoped-modules@^1.0.0:
     dezalgo "^1.0.0"
     graceful-fs "^4.1.2"
     once "^1.3.0"
+
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+  dependencies:
+    picomatch "^2.2.1"
 
 redent@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This improves the developer experience and productivity to contribute to the bison template. It enables you to  make changes directly to files in `packages/create-bison-app/template/` and have it live reload a running bison app.

This adds a `yarn dev` script in `packages/create-bison-app` which will do the following:

1. Creates a new bison app in `packages/create-bison-app/dist/bison-dev-app`
   -  If `packages/create-bison-app/dist/bison-dev-app` already exists, this step will be skipped
   -  A `bison.json` file will also be created that contains all the variables for template rendering. This is needed later to watch and re-render EJS files. This file will **only** be created for this dev app and not other bison apps.
   -  Symbolic links to node modules and generated files are created in `packages/create-bison-app/template/` so the files won't contain errors for missing imported modules
1. Runs `yarn db:setup && yarn generate`
   -  If `packages/create-bison-app/dist/bison-dev-app` already exists, this step will be skipped
1. Uses our `startServer` script to run `yarn next dev` 
1. Starts watching the `packages/create-bison-app/template/` folder for changes. Anytime a file is changed, it will be copied to `packages/create-bison-app/dist/bison-dev-app/` where the app is actually running.
   -  For EJS files, it will use the `bison.json` file mentioned above as variables to render the template


Examples of supported arguments:
- `yarn dev --acceptDefaults`
   -  Skip interactive prompts if a new bison app is being created
- `yarn dev --clean`
   -  This will delete `packages/create-bison-app/dist/bison-dev-app`, unlink node modules and generated files, and create a new bison app
- `yarn dev --port=5000`
    - Port to use for dev app. Defaults to 3001.


## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works