### PR TITLE
fix: update setupDB command to not fail when run multiple times

### DIFF
--- a/packages/create-bison-app/template/tests/helpers.ts
+++ b/packages/create-bison-app/template/tests/helpers.ts
@@ -85,7 +85,7 @@ export const resetDB = async (): Promise<boolean> => {
  */
 export const setupDB = async (): Promise<boolean> => {
   // ensure the db is created and migrated
-  await exec(`yarn prisma migrate deploy`);
+  await exec(`yarn prisma migrate reset --force`);
 
   return true;
 };


### PR DESCRIPTION
This fixes the command being run in `setupDB` to not fail in cypress tests when run multiple times on the same database.

## Changes

- Replace `prisma deploy` with `prisma reset` so it will drop the database if it exists and then run migrations 

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works

Fixes #170 
