### PR TITLE
feat(enhancement): Upgrades generated graphql nexus file with more CRUD examples

### DIFF
--- a/packages/create-bison-app/template/_templates/graphql/new/graphql.ejs
+++ b/packages/create-bison-app/template/_templates/graphql/new/graphql.ejs
@@ -3,27 +3,18 @@ to: graphql/modules/<%= name %>.ts
 ---
 <% camelized = h.inflection.camelize(name) -%>
 <% plural = h.inflection.pluralize(camelized) -%>
-import { objectType, extendType, inputObjectType, list, arg, nonNull /*, enumType*/ } from 'nexus';
+import { objectType, extendType, inputObjectType, arg, nonNull /*, enumType*/ } from 'nexus';
 
 import { isAdmin } from '../../services/permissions';
-
-// Example ENUM Type
-// import { Role } from '@prisma/client';
-// export const UserRole = enumType({
-//   name: 'Role',
-//   members: Object.values(Role),
-// });
 
 // <%= camelized %> Type
 export const <%= camelized %> = objectType({
   name: '<%= camelized %>',
   description: 'A <%= camelized %>',
   definition(t) {
-    // Database Specific Fields
     t.nonNull.id('id');
     t.nonNull.date('createdAt');
     t.nonNull.date('updatedAt');
-    // Model Specific Fields
     t.nonNull.string('name');
   },
 });
@@ -33,8 +24,8 @@ export const <%= camelized %>Queries = extendType({
   type: 'Query',
   definition: (t) => {
     // List <%= plural %> Query
-    t.field('<%= plural.toLowerCase() %>', {
-      type: list('<%= camelized %>'),
+    t.list.field('<%= plural.toLowerCase() %>', {
+      type: '<%= camelized %>',
       authorize: (_root, _args, ctx) => !!ctx.user,
       args: {
         where: arg({ type: '<%= camelized %>WhereInput' }),

--- a/packages/create-bison-app/template/_templates/graphql/new/graphql.ejs
+++ b/packages/create-bison-app/template/_templates/graphql/new/graphql.ejs
@@ -3,20 +3,28 @@ to: graphql/modules/<%= name %>.ts
 ---
 <% camelized = h.inflection.camelize(name) -%>
 <% plural = h.inflection.pluralize(camelized) -%>
-import { objectType, extendType, inputObjectType, stringArg, arg, nonNull, enumType } from 'nexus';
-import { Role } from '@prisma/client';
-import { UserInputError, /*ForbiddenError*/ } from 'apollo-server-micro';
+import { objectType, extendType, inputObjectType, list, arg, nonNull /*, enumType*/ } from 'nexus';
 
-// import { isAdmin } from '../services/permissions';
+import { isAdmin } from '../../services/permissions';
+
+// Example ENUM Type
+// import { Role } from '@prisma/client';
+// export const UserRole = enumType({
+//   name: 'Role',
+//   members: Object.values(Role),
+// });
 
 // <%= camelized %> Type
 export const <%= camelized %> = objectType({
   name: '<%= camelized %>',
   description: 'A <%= camelized %>',
   definition(t) {
+    // Database Specific Fields
     t.nonNull.id('id');
     t.nonNull.date('createdAt');
     t.nonNull.date('updatedAt');
+    // Model Specific Fields
+    t.nonNull.string('name');
   },
 });
 
@@ -25,21 +33,32 @@ export const <%= camelized %>Queries = extendType({
   type: 'Query',
   definition: (t) => {
     // List <%= plural %> Query
-    t.list.field('<%= plural.toLowerCase() %>', {
-      type: '<%= camelized %>',
+    t.field('<%= plural.toLowerCase() %>', {
+      type: list('<%= camelized %>'),
       authorize: (_root, _args, ctx) => !!ctx.user,
-      args: nonNull(arg({ type: 'SomethingQueryInput' })),
-      description: 'Returns available <%= plural.toLowerCase() %>',
+      args: {
+        where: arg({ type: '<%= camelized %>WhereInput' }),
+        orderBy: arg({ type: '<%= camelized %>OrderByInput', list: true }),
+      },
+      description: 'Returns found <%= plural.toLowerCase() %>',
+      resolve: async (_root, args, ctx) => {
+        const { where = {}, orderBy = [] } = args;
+
+        return await ctx.db.<%= name %>.findMany({ where, orderBy });
+      }
     })
 
     // single query
-    t.field('something', {
+    t.field('<%= name.toLowerCase() %>', {
       type: '<%= camelized %>',
       description: 'Returns a specific <%= camelized %>',
       authorize: (_root, _args, ctx) => !!ctx.user,
-      args: nonNull(arg({ type: 'SomethingQueryInput' })),
+      args: {
+        where: nonNull(arg({ type: '<%= camelized%>WhereUniqueInput' }))
+      },
       resolve: (_root, args, ctx) => {
-        // TODO
+        const { where } = args;
+        return ctx.prisma.<%= name %>.findUnique({ where })
       },
     });
   },
@@ -49,60 +68,75 @@ export const <%= camelized %>Queries = extendType({
 export const <%= camelized %>Mutations = extendType({
   type: 'Mutation',
   definition: (t) => {
-    t.field('somethingMutation', {
-      type: 'String',
-      description: 'Does something',
+    t.field('create<%= camelized %>', {
+      type: '<%= camelized %>',
+      description: 'Creates a <%= camelized %>',
+      authorize: (_root, _args, ctx) => isAdmin(ctx.user),
       args: {
-        data: nonNull(arg({ type: 'SomethingMutationInput' })),
+        data: nonNull(arg({ type: 'Create<%= camelized %>Input' })),
       },
-      authorize: (_root, _args, ctx) => !!ctx.user,
       resolve: async (_root, args, ctx) => {
-        console.log(args.data.hello)
-        return args.data.hello
+        return await ctx.db.<%= name %>.create(args);
+      }
+    });
+
+    t.field('update<%= camelized %>', {
+      type: '<%= camelized %>',
+      description: 'Updates a <%= camelized %>',
+      authorize: (_root, _args, ctx) => isAdmin(ctx.user),
+      args: {
+        where: nonNull(arg({ type: '<%= camelized %>WhereUniqueInput'})),
+        data: nonNull(arg({ type: 'Update<%= camelized %>Input' })),
+      },
+      resolve: async (_root, args, ctx) => {
+        const { where, data } = args;
+
+        return await ctx.db.<%= name %>.update({ where, data });
       }
     });
   },
 });
 
-// Inputs
-export const SomethingMutationInput = inputObjectType({
-  name: 'SomethingMutationInput',
-  description: 'Input used to do something',
+// MUTATION INPUTS
+export const Create<%= camelized %>Input = inputObjectType({
+  name: 'Create<%= camelized %>Input',
+  description: 'Input used to create a <%= name %>',
   definition: (t) => {
-    t.nonNull.string('hello');
-  },
-})
-
-export const SomethingQueryInput = inputObjectType({
-  name: 'SomethingQueryInput',
-  description: 'Input used to do something',
-  definition: (t) => {
-    t.nonNull.string('hello');
+    t.nonNull.string('name');
   },
 });
 
+export const Update<%= camelized %>Input = inputObjectType({
+  name: 'Update<%= camelized %>Input',
+  description: 'Input used to update a <%= name %>',
+  definition: (t) => {
+    t.nonNull.string('name');
+  },
+});
+
+// QUERY INPUTS
 export const <%= camelized %>OrderByInput = inputObjectType({
   name: '<%= camelized %>OrderByInput',
   description: 'Order <%= camelized.toLowerCase() %> by a specific field',
   definition(t) {
-    t.field('hello', { type: 'SortOrder' });
+    t.field('name', { type: 'SortOrder' });
   },
 });
 
-export const UserWhereUniqueInput = inputObjectType({
-  name: 'UserWhereUniqueInput',
-  description: 'Input to find users based on unique fields',
+export const <%= camelized %>WhereUniqueInput = inputObjectType({
+  name: '<%= camelized %>WhereUniqueInput',
+  description: 'Input to find <%= plural.toLowerCase() %> based on unique fields',
   definition(t) {
     t.id('id');
-    t.email('email');
+    // add DB uniq fields here
+    // t.string('name');
   },
 });
 
-export const UserWhereInput = inputObjectType({
-  name: 'UserWhereInput',
-  description: 'Input to find users based other fields',
+export const <%= camelized %>WhereInput = inputObjectType({
+  name: '<%= camelized %>WhereInput',
+  description: 'Input to find <%= plural.toLowerCase() %> based on other fields',
   definition(t) {
-    t.int('id');
-    t.field('email', { type: 'StringFilter' });
+    t.field('name', { type: 'StringFilter' });
   },
 });


### PR DESCRIPTION
## Description 
Upgrades generated graphql nexus file with more CRUD examples and proper Input Types

## Changes
GraphQL Nexus template was lacking, had bogus "SOMETHING" and User definitions. 

Now generates: 
- Base Module 
- Query `thing` w/ user logged in guard
- Query `list('thing')` w/ user logged in guard
- Mutation `createThing` w/ `isAdmin` guard
- Mutation `updateThing` w/ `IsAdmin` guard
- ThingWhereInput
- ThingWhereUniqueInput 
- ThingCreateInput
- ThingUpdateInput
- ThingOrderByInput

- [x] Generating a new app works

closes https://github.com/echobind/bisonapp/issues/173
