### PR TITLE
fix: removing symlinked files and directories

### DIFF
--- a/packages/create-bison-app/scripts/createDevAppAndStartServer.js
+++ b/packages/create-bison-app/scripts/createDevAppAndStartServer.js
@@ -19,8 +19,8 @@ async function init() {
   const { clean, port } = yargs(args).argv;
 
   if (clean) {
-    await fs.promises.rmdir(devAppPath, { recursive: true });
     await removeTemplateSymlinks();
+    await fs.promises.rm(devAppPath, { force: true, recursive: true });
   }
 
   // Create bison app if it does not exist
@@ -85,7 +85,8 @@ async function removeTemplateSymlinks() {
   const templatePath = relativePath => path.join(templateFolder, relativePath);
   const unlinkFile = async filename => {
     const filePath = templatePath(filename);
-    if (fs.existsSync(filePath) && fs.lstatSync(filePath).isSymbolicLink()) {
+    const lstat = fs.lstatSync(filePath, { throwIfNoEntry: false });
+    if (lstat && lstat.isSymbolicLink()) {
       await fs.promises.unlink(filePath);
     }
   }
@@ -94,8 +95,8 @@ async function removeTemplateSymlinks() {
   await unlinkFile("types.ts");
 
   // Directories cannot be "unlinked" so they must be removed
-  await fs.promises.rmdir(templatePath("node_modules"), { recursive: true });
-  await fs.promises.rmdir(templatePath("types"), { recursive: true });
+  await fs.promises.rm(templatePath("node_modules"), { force: true, recursive: true });
+  await fs.promises.rm(templatePath("types"), { force: true, recursive: true });
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Changes

This fixes errors occurring when running `yarn dev --clean`:
- Update to not throw errors when removing directories if they don't exist
- Improves checking if symlinked files exist before removing. There were certain conditions where these were not being cleaned up.
- Updates to use `rm` instead of `rmdir` which is deprecated in node 16

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works