### PR TITLE
fix: do not remove file extension from hygen templates when copied by dev server

### DIFF
--- a/packages/create-bison-app/scripts/createDevAppAndStartServer.js
+++ b/packages/create-bison-app/scripts/createDevAppAndStartServer.js
@@ -46,9 +46,13 @@ async function init() {
   ));
 
   const copyFile = async (src) => {
-    const relativeSrc = cleanTemplateDestPath(src.replace(templateFolder, ""));
-    const dest = path.join(devAppPath, relativeSrc);
-    if (src.match(/\.ejs$/) && !src.match(/_templates\//)) {
+    const relativeSrc = src.replace(templateFolder, "");
+    const isHygenTemplate = src.match(/_templates\//);
+    const dest = path.join(
+      devAppPath,
+      isHygenTemplate ? relativeSrc : cleanTemplateDestPath(relativeSrc)
+    );
+    if (src.match(/\.ejs$/) && !isHygenTemplate) {
       await copyWithTemplate(src, dest, templateVariables);
     } else {
       await fs.promises.copyFile(src, dest);


### PR DESCRIPTION
The extension for the hygen templates was being removed when copied by the dev server:
![Screen Shot 2021-07-01 at 5 45 15 PM](https://user-images.githubusercontent.com/1087679/124195106-b7976000-da97-11eb-9263-9216a272bd82.png)

## Changes

- Updates to check if the changed file is a hygen template, if so do not call the `cleanTemplateDestPath` function which strips the file extension

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works