### PR TITLE
fix: refactor scripts import in the create-bison-app script into utils file

### DIFF
--- a/packages/create-bison-app/index.js
+++ b/packages/create-bison-app/index.js
@@ -7,8 +7,8 @@ const Listr = require("listr");
 const nodegit = require("nodegit");
 const ejs = require("ejs");
 const color = require("chalk");
-const { BISON_DEV_APP_VARIABLES_FILE } = require("./scripts/createDevAppAndStartServer");
 const { copyFiles } = require("./tasks/copyFiles");
+const { saveDevAppVariables } = require("./utils/devAppVariables");
 const { version: bisonVersion } = require("./package.json");
 
 module.exports = async ({ name, ...answers }) => {
@@ -144,10 +144,7 @@ module.exports = async ({ name, ...answers }) => {
       task: async () => {
         // Save variables to file so template directory can be watched
         // and render templates again using same variables
-        await fs.promises.writeFile(
-          path.join(targetFolder, BISON_DEV_APP_VARIABLES_FILE), 
-          JSON.stringify(variables, null, 2)
-        );
+        await saveDevAppVariables(targetFolder, variables);
       },
     },
   ]);

--- a/packages/create-bison-app/scripts/createDevAppAndStartServer.js
+++ b/packages/create-bison-app/scripts/createDevAppAndStartServer.js
@@ -8,9 +8,9 @@ const { startServer } = require("../scripts/startServer");
 const { templateFolder } = require("../tasks/copyFiles");
 const { cleanTemplateDestPath } = require("../utils/copyDirectoryWithTemplate");
 const { copyWithTemplate } = require("../utils/copyWithTemplate");
+const { getDevAppVariables } = require("../utils/devAppVariables");
 
 const BISON_DEV_APP_NAME = "bison-dev-app";
-const BISON_DEV_APP_VARIABLES_FILE = "bison.json";
 
 async function init() {
   const distPath = path.join(__dirname, "..", "dist");
@@ -40,10 +40,7 @@ async function init() {
     await createTemplateSymlinks(devAppPath);
   }
 
-  const templateVariables = require(path.join(
-    devAppPath,
-    BISON_DEV_APP_VARIABLES_FILE
-  ));
+  const templateVariables = getDevAppVariables(devAppPath);
 
   const copyFile = async (src) => {
     const relativeSrc = src.replace(templateFolder, "");
@@ -111,7 +108,3 @@ async function removeTemplateSymlinks() {
 if (require.main === module) {
   init();
 }
-
-module.exports = {
-  BISON_DEV_APP_VARIABLES_FILE,
-};

--- a/packages/create-bison-app/utils/devAppVariables.js
+++ b/packages/create-bison-app/utils/devAppVariables.js
@@ -1,0 +1,23 @@
+const fs = require("fs");
+const path = require("path");
+
+const BISON_DEV_APP_VARIABLES_FILE = "bison.json";
+
+function getDevAppVariables(appPath) {
+  return require(path.join(
+    appPath,
+    BISON_DEV_APP_VARIABLES_FILE
+  ));
+}
+
+async function saveDevAppVariables(appPath, variables) {
+  await fs.promises.writeFile(
+    path.join(appPath, BISON_DEV_APP_VARIABLES_FILE),
+    JSON.stringify(variables, null, 2)
+  );
+}
+
+module.exports = {
+  getDevAppVariables,
+  saveDevAppVariables
+};


### PR DESCRIPTION
## Changes

The `scripts/*` files shouldn't be imported into other modules so this refactors getting and saving dev app variables into a utility file.

Fixes this error occurring when creating a new app:

<img width="460" alt="Screen Shot 2021-07-15 at 5 08 01 PM" src="https://user-images.githubusercontent.com/1087679/125857945-b93a2c0c-8bcf-41cc-be35-47297e73e5a4.png">

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works