### PR TITLE
ci: trigger on pull request event

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,10 @@
 name: Run Tests
-on: [push]
+on:
+  push:
+    branches:
+      - canary
+      - main
+  pull_request:
 
 jobs:
   release:


### PR DESCRIPTION
Currently, our tests workflow is not running on dependabot or public fork PRs so this adds the `pull_request` event as a trigger.

By default, first time contributors should need to get approval before the workflows run:
https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/disabling-or-limiting-github-actions-for-a-repository#configuring-required-approval-for-workflows-from-public-forks

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works