### PR TITLE
Ci/template node 16

### DIFF
--- a/packages/create-bison-app/template/.github/workflows/main.js.yml.ejs
+++ b/packages/create-bison-app/template/.github/workflows/main.js.yml.ejs
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2.1.2
         with:
-          node-version: 14.6.0
+          node-version: 16
 
       # Yarn cache/install
       - name: Find yarn cache location

--- a/packages/create-bison-app/template/.github/workflows/main.js.yml.ejs
+++ b/packages/create-bison-app/template/.github/workflows/main.js.yml.ejs
@@ -84,6 +84,7 @@ jobs:
         env:
           NODE_ENV: test
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APP_SECRET: foo
           DATABASE_URL: postgresql://postgres:postgres@localhost/myapp_test
 
       - name: Upload Cypress Screenshots


### PR DESCRIPTION
## Changes

Updates CI to run on node 16 to fix the following error occurring in newly created bison apps: 
<img width="1332" alt="Screen Shot 2021-08-13 at 6 56 13 PM" src="https://user-images.githubusercontent.com/1087679/129425977-9e208f20-e16b-4c30-a67d-f4be8b8e910c.png">

This also adds the `APP_SECRET` environment variable needed for the cypress tests. While not the best solution, it gets the CI tests to pass out of the box; otherwise it is really difficult to debug why the tests are failing. #153 is a related issue to determine the best way to handle this.

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works

Fixes #204 
