### PR TITLE
ci: run release workflow on node 16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2.1.2
         with:
-          node-version: 14.6.0
+          node-version: 16
           registry-url: https://registry.npmjs.org
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Runs "Release" workflow on node 16 so dependencies can be installed: https://github.com/echobind/bisonapp/runs/3678001603?check_suite_focus=true#step:7:14

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works
