### PR TITLE
feat: add ability to run any bison dev app script

### DIFF
--- a/packages/create-bison-app/CONTRIBUTING.md
+++ b/packages/create-bison-app/CONTRIBUTING.md
@@ -5,14 +5,23 @@
 Run the following commands in the `packages/create-bison-app` directory to start the development server:
 
 1. Run `yarn install` to install dependencies
-1. Run `yarn dev` to create a Bison app and start the server. Optionally, you may pass the following arguments:
+1. Run `yarn dev` to create a Bison app and start the server. Optionally, you may pass the following arguments and options:
+   - `[script]` Any script in the template's [package.json](/packages/create-bison-app/template/package.json.ejs). By default, the `dev` script is run.
    - `--acceptDefaults` Skip interactive prompts and use default options to create a new Bison app
    - `--clean` When running `yarn dev` subsequent times, use this to reconfigure and create a new Bison app
-   - `--port` Specify the port to listen on. Defaults to 3001.
 
-Example:
+### Example Usages
+
+Start the development server:
+
 ```
-yarn dev --acceptDefaults --clean --port=5000
+yarn dev --acceptDefaults --clean
+```
+
+Run the `test` script in the template's [package.json](/packages/create-bison-app/template/package.json.ejs):
+
+```
+yarn dev test
 ```
 
 ## Making Changes to the Bison Template


### PR DESCRIPTION
## Changes

This is an improvement to the development workflow for the template. Before this change, you could only run `yarn dev` (from `packages/create-bison-app`) to run the template's `dev` script. This is still the default functionality.

Now in addition to that, `yarn dev` supports a new optional argument: `yarn dev [script]`

So from the `packages/create-bison-app` directory, you can run `yarn dev [script]` where `[script]` is the name of any script in `packages/create-bison-app/dist/bison-dev-app/package.json`. For example, you can run `yarn dev test` to run the "test" script in the bison app.

## How to test

In the `packages/create-bison-app` directory, you can run `yarn dev test`, `yarn dev build:types`, or any script from the template's [package.json](https://github.com/echobind/bisonapp/blob/canary/packages/create-bison-app/template/package.json.ejs#L8).

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works
