### PR TITLE
chore: pin down cypress version to 8.5

### DIFF
--- a/packages/create-bison-app/template/package.json.ejs
+++ b/packages/create-bison-app/template/package.json.ejs
@@ -93,7 +93,7 @@
     "chance": "^1.1.6",
     "concurrently": "^5.2.0",
     "cross-env": "^7.0.3",
-    "cypress": "^8.3.0",
+    "cypress": "~8.5.0",
     "eslint": "^7.5.0",
     "eslint-config-next": "^11.0.1",
     "eslint-plugin-cypress": "^2.11.1",


### PR DESCRIPTION
Temporary fix for CI cypress failures.

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works