### PR TITLE
feat: Make external links themeable with Chakra UI

### DIFF
--- a/packages/create-bison-app/template/components/Footer.tsx
+++ b/packages/create-bison-app/template/components/Footer.tsx
@@ -1,4 +1,4 @@
-import { Center, Flex, Text } from '@chakra-ui/layout';
+import { Center, Flex, Text, Link } from '@chakra-ui/layout';
 
 import { Logo } from './Logo';
 
@@ -11,9 +11,9 @@ export function Footer() {
         <Logo />
         <Text as="em" textAlign="center">
           Copyright Ⓒ {year}{' '}
-          <a href="https://echobind.com" target="_blank" rel="noopener noreferrer">
+          <Link href="https://echobind.com" isExternal>
             Echobind LLC.
-          </a>{' '}
+          </Link>{' '}
           All rights reserved.
         </Text>
       </Flex>


### PR DESCRIPTION
External links are currently implemented with `<a>` tags in JSX. Chakra UI has a `Link` component which has the same functionality as `a`, while also making the links themeable through variants defined in the default or a custom theme via Chakra's theming API. See [this discussion](https://github.com/echobind/bisonapp/pull/235/commits/772a792b8aad287716ccf613fce8244071a75c91#r731948796) for context and an example. 

## Changes

- Replaces use of anchor tags for external links with the `Link` component from Chakra UI
- Replace the use of `target="_blank"` and `rel="noopener noreferrer"` attributes on external links with the `isExternal` prop on the substituted `Link` components which provides the same functionality


## Screenshots

![themable-links](https://user-images.githubusercontent.com/61833561/138159803-ba2ce611-4b76-4ad1-af58-55496a3661c5.gif)

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works
