### PR TITLE
fix: generate initial types before db:setup

### DIFF
--- a/packages/create-bison-app/template/package.json.ejs
+++ b/packages/create-bison-app/template/package.json.ejs
@@ -34,7 +34,7 @@
     "g:test:util": "hygen test util --name",
     "lint": "yarn eslint . --ext .ts,.tsx --fix --ignore-pattern tmp",
     "run:script": "yarn ts-node prisma/scripts/run.ts -f",
-    "setup:dev": "yarn build:types && yarn db:setup",
+    "setup:dev": "yarn db:deploy && yarn build:types && yarn db:seed",
     "start": "next start -p $PORT",
     "test": "yarn withEnv:test jest --runInBand --watch",
     "test:ci": "yarn withEnv:test jest --runInBand",

--- a/packages/create-bison-app/template/package.json.ejs
+++ b/packages/create-bison-app/template/package.json.ejs
@@ -34,7 +34,7 @@
     "g:test:util": "hygen test util --name",
     "lint": "yarn eslint . --ext .ts,.tsx --fix --ignore-pattern tmp",
     "run:script": "yarn ts-node prisma/scripts/run.ts -f",
-    "setup:dev": "yarn db:setup && yarn build:types",
+    "setup:dev": "yarn build:types && yarn db:setup",
     "start": "next start -p $PORT",
     "test": "yarn withEnv:test jest --runInBand --watch",
     "test:ci": "yarn withEnv:test jest --runInBand",


### PR DESCRIPTION
## Changes
- setup:dev now builds types before seeding

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works

