### PR TITLE
fix: The DATABASE_URL set in .env.test doesn't include a colon between the username and password.

### DIFF
--- a/packages/create-bison-app/template/_.env.test.ejs
+++ b/packages/create-bison-app/template/_.env.test.ejs
@@ -1,3 +1,3 @@
 # ENV vars here override .env when running tests
-DATABASE_URL="postgresql://<%= db.dev.user %><%= db.dev.password %>@<%= db.dev.host %>:<%= db.dev.port %>/<%= db.test.name %>?schema=public"
+DATABASE_URL="postgresql://<%= db.dev.user %><% if (db.dev.password) { %>:<%= db.dev.password %><% } %>@<%= db.dev.host %>:<%= db.dev.port %>/<%= db.test.name %>?schema=public"
 APP_SECRET=foo


### PR DESCRIPTION
If you provide a database password during setup, the `DATABASE_URL` set in `.env.test` will not have a colon between the username and password. If no password is provided, it works fine.

## Changes

- [x] Update `_.env.test.ejs` to put a colon between the username and password if a password is provided.

## Checklist

- [x] Generating a new app works
