### PR TITLE
feat: add vscode debug configurations

### DIFF
--- a/packages/create-bison-app/template/.vscode/launch.json
+++ b/packages/create-bison-app/template/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Bison: Seed database",
+      "type": "pwa-node",
+      "request": "launch",
+      "skipFiles": ["<node_internals>/**"],
+      "runtimeArgs": ["-r", "ts-node/register", "-r"],
+      "args": ["${workspaceFolder}/prisma/seed.ts"]
+    },
+    {
+      "name": "Bison: Build (Production)",
+      "type": "pwa-node",
+      "request": "launch",
+      "skipFiles": ["<node_internals>/**"],
+      "runtimeArgs": ["-r", "ts-node/register", "-r"],
+      "args": ["${workspaceFolder}/scripts/buildProd.ts"]
+    },
+    {
+      "name": "Bison: debug server-side",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "yarn dev"
+    },
+    {
+      "name": "Bison: debug client-side",
+      "type": "pwa-chrome",
+      "request": "launch",
+      "url": "http://localhost:3000"
+    },
+    {
+      "name": "Bison: debug full stack",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "yarn dev",
+      "console": "integratedTerminal",
+      "serverReadyAction": {
+        "pattern": "started server on .+, url: (https?://.+)",
+        "uriFormat": "%s",
+        "action": "debugWithChrome"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds several VSCode debugging configurations (`.vscode/launch.json`) to the default Bison template. Next.js now has [recommended configs](https://nextjs.org/docs/advanced-features/debugging#debugging-with-vs-code) for VSCode, which can be used to debug client and server code by setting breakpoints directly in the IDE. In addition to these debug configs, two more are included for debugging production builds and database seeding.

## Changes

- Create a `.vscode/launch.json` file in the default Bison template and add debug configs recommended by Next.js team
- Add two additional configs for debugging production builds and database seeding in Bison

## Screenshots

![CleanShot 2022-03-17 at 15 13 53](https://user-images.githubusercontent.com/61833561/158879032-fae080f8-456e-42c1-82ed-e708cb9c4baa.gif)


## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works
