### PR TITLE
Add Postgres download link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ npx create-bison-app MyApp
 
 ## Setup the database
 
-1. Setup a database locally (Postgres is the only type fully supported right now)
+1. Setup a database locally ([Postgres](https://postgresapp.com/downloads.html) is the only type fully supported right now)
 1. Make sure your database user has permission to create schemas and databases. We recommend using a superuser account locally to keep things easy.
 1. Setup your local database with `yarn db:setup`. You'll be prompted to create it if it doesn't already exist:
 


### PR DESCRIPTION
This PR adds a link to download Postgres to the README to reduce ambiguity.

## Changes

- README: link "Postgres" to their download page


## Screenshots
<img width="480" alt="Screen Shot 2022-04-05 at 2 08 01 PM" src="https://user-images.githubusercontent.com/17681528/161831051-5ea04cb9-99f0-4fd7-a811-8d7c291d41ef.png">


## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works
