### PR TITLE
adding a Comparison scalar and surfacing it in definition block for S…

### DIFF
--- a/packages/create-bison-app/template/graphql/modules/scalars.ts
+++ b/packages/create-bison-app/template/graphql/modules/scalars.ts
@@ -6,9 +6,59 @@ import {
   URLResolver,
 } from 'graphql-scalars';
 import { asNexusMethod } from 'nexus';
+import { GraphQLScalarType, Kind } from 'graphql';
+
+export const ComparisonOperatorScalarType = new GraphQLScalarType({
+  name: 'ComparisonOperator',
+  description: 'Allows values typically used in comparison operators: string, number, Date object',
+  // parseValue and serialize are used to ensure validity
+  parseValue: (value) => {
+    return typeof value === 'object' || typeof value === 'string' || typeof value === 'number' ? value
+      : null
+  },
+  serialize: (value) => {
+    return typeof value === 'object' || typeof value === 'string' || typeof value === 'number' ? value
+      : null
+  },
+  parseLiteral: (ast) => {
+    switch (ast.kind) {
+      case Kind.STRING:
+      case Kind.INT:
+        return ast.value;
+      case Kind.OBJECT: return parseObject(ast);
+      default: return null
+    }
+  }
+});
+
+const parseObject = (ast) => {
+  const value = Object.create(null);
+  ast.fields.forEach((field) => {
+    value[field.name.value] = parseAst(field.value);
+  });
+  return value;
+}
+
+const parseAst = (ast) => {
+  switch (ast.kind) {
+    case Kind.STRING:
+    case Kind.BOOLEAN:
+      return ast.value;
+    case Kind.INT:
+    case Kind.FLOAT:
+      return parseFloat(ast.value);
+    case Kind.OBJECT:
+      return parseObject(ast);
+    case Kind.LIST:
+      return ast.values.map(parseAst);
+    default:
+      return null;
+  }
+};
 
 export const JSON = asNexusMethod(JSONObjectResolver, 'json');
 export const DateTime = asNexusMethod(DateTimeResolver, 'date');
 export const Email = asNexusMethod(EmailAddressResolver, 'email');
 export const PhoneNumber = asNexusMethod(PhoneNumberResolver, 'phone');
 export const URL = asNexusMethod(URLResolver, 'url');
+export const Comparison = asNexusMethod(ComparisonOperatorScalarType, 'compare');

--- a/packages/create-bison-app/template/graphql/modules/scalars.ts
+++ b/packages/create-bison-app/template/graphql/modules/scalars.ts
@@ -5,10 +5,10 @@ import {
   PhoneNumberResolver,
   URLResolver,
 } from 'graphql-scalars';
-import { asNexusMethod } from 'nexus';
-import { GraphQLScalarType, Kind } from 'graphql';
+import { asNexusMethod, scalarType } from 'nexus';
+import { Kind, ObjectValueNode, ValueNode } from 'graphql';
 
-export const ComparisonOperatorScalarType = new GraphQLScalarType({
+export const ComparisonOperatorScalarType = scalarType({
   name: 'ComparisonOperator',
   description: 'Allows values typically used in comparison operators: string, number, Date object',
   // parseValue and serialize are used to ensure validity
@@ -20,7 +20,7 @@ export const ComparisonOperatorScalarType = new GraphQLScalarType({
     return typeof value === 'object' || typeof value === 'string' || typeof value === 'number' ? value
       : null
   },
-  parseLiteral: (ast) => {
+  parseLiteral: (ast: ValueNode) => {
     switch (ast.kind) {
       case Kind.STRING:
       case Kind.INT:
@@ -28,10 +28,11 @@ export const ComparisonOperatorScalarType = new GraphQLScalarType({
       case Kind.OBJECT: return parseObject(ast);
       default: return null
     }
-  }
+  },
+  asNexusMethod: 'compare'
 });
 
-const parseObject = (ast) => {
+const parseObject = (ast: ObjectValueNode) => {
   const value = Object.create(null);
   ast.fields.forEach((field) => {
     value[field.name.value] = parseAst(field.value);
@@ -39,7 +40,7 @@ const parseObject = (ast) => {
   return value;
 }
 
-const parseAst = (ast) => {
+const parseAst = (ast: ValueNode): any => {
   switch (ast.kind) {
     case Kind.STRING:
     case Kind.BOOLEAN:
@@ -61,4 +62,3 @@ export const DateTime = asNexusMethod(DateTimeResolver, 'date');
 export const Email = asNexusMethod(EmailAddressResolver, 'email');
 export const PhoneNumber = asNexusMethod(PhoneNumberResolver, 'phone');
 export const URL = asNexusMethod(URLResolver, 'url');
-export const Comparison = asNexusMethod(ComparisonOperatorScalarType, 'compare');

--- a/packages/create-bison-app/template/graphql/modules/scalars.ts
+++ b/packages/create-bison-app/template/graphql/modules/scalars.ts
@@ -6,33 +6,6 @@ import {
   URLResolver,
 } from 'graphql-scalars';
 import { asNexusMethod } from 'nexus';
-import { Kind, ObjectValueNode, ValueNode } from 'graphql';
-
-const parseObject = (ast: ObjectValueNode) => {
-  const value = Object.create(null);
-  ast.fields.forEach((field) => {
-    value[field.name.value] = parseAst(field.value);
-  });
-
-  return value;
-};
-
-const parseAst = (ast: ValueNode): any => {
-  switch (ast.kind) {
-    case Kind.STRING:
-    case Kind.BOOLEAN:
-      return ast.value;
-    case Kind.INT:
-    case Kind.FLOAT:
-      return parseFloat(ast.value);
-    case Kind.OBJECT:
-      return parseObject(ast);
-    case Kind.LIST:
-      return ast.values.map(parseAst);
-    default:
-      return null;
-  }
-};
 
 export const JSON = asNexusMethod(JSONObjectResolver, 'json');
 export const DateTime = asNexusMethod(DateTimeResolver, 'date');

--- a/packages/create-bison-app/template/graphql/modules/scalars.ts
+++ b/packages/create-bison-app/template/graphql/modules/scalars.ts
@@ -13,12 +13,14 @@ export const ComparisonOperatorScalarType = scalarType({
   description: 'Allows values typically used in comparison operators: string, number, Date object',
   // parseValue and serialize are used to ensure validity
   parseValue: (value) => {
-    return typeof value === 'object' || typeof value === 'string' || typeof value === 'number' ? value
-      : null
+    return typeof value === 'object' || typeof value === 'string' || typeof value === 'number' 
+    ? value
+      : null;
   },
   serialize: (value) => {
-    return typeof value === 'object' || typeof value === 'string' || typeof value === 'number' ? value
-      : null
+    return typeof value === 'object' || typeof value === 'string' || typeof value === 'number' 
+    ? value
+      : null;
   },
   parseLiteral: (ast: ValueNode) => {
     switch (ast.kind) {
@@ -26,10 +28,11 @@ export const ComparisonOperatorScalarType = scalarType({
       case Kind.INT:
         return ast.value;
       case Kind.OBJECT: return parseObject(ast);
-      default: return null
+      default:
+        return null
     }
   },
-  asNexusMethod: 'compare'
+  asNexusMethod: 'compare',
 });
 
 const parseObject = (ast: ObjectValueNode) => {
@@ -38,7 +41,7 @@ const parseObject = (ast: ObjectValueNode) => {
     value[field.name.value] = parseAst(field.value);
   });
   return value;
-}
+};
 
 const parseAst = (ast: ValueNode): any => {
   switch (ast.kind) {

--- a/packages/create-bison-app/template/graphql/modules/scalars.ts
+++ b/packages/create-bison-app/template/graphql/modules/scalars.ts
@@ -5,36 +5,8 @@ import {
   PhoneNumberResolver,
   URLResolver,
 } from 'graphql-scalars';
-import { asNexusMethod, scalarType } from 'nexus';
+import { asNexusMethod } from 'nexus';
 import { Kind, ObjectValueNode, ValueNode } from 'graphql';
-
-export const ComparisonOperatorScalarType = scalarType({
-  name: 'ComparisonOperator',
-  description: 'Allows values typically used in comparison operators: string, number, Date object',
-  // parseValue and serialize are used to ensure validity
-  parseValue: (value) => {
-    return typeof value === 'object' || typeof value === 'string' || typeof value === 'number'
-      ? value
-      : null;
-  },
-  serialize: (value) => {
-    return typeof value === 'object' || typeof value === 'string' || typeof value === 'number'
-      ? value
-      : null;
-  },
-  parseLiteral: (ast: ValueNode) => {
-    switch (ast.kind) {
-      case Kind.STRING:
-      case Kind.INT:
-        return ast.value;
-      case Kind.OBJECT:
-        return parseObject(ast);
-      default:
-        return null;
-    }
-  },
-  asNexusMethod: 'compare',
-});
 
 const parseObject = (ast: ObjectValueNode) => {
   const value = Object.create(null);

--- a/packages/create-bison-app/template/graphql/modules/scalars.ts
+++ b/packages/create-bison-app/template/graphql/modules/scalars.ts
@@ -13,13 +13,13 @@ export const ComparisonOperatorScalarType = scalarType({
   description: 'Allows values typically used in comparison operators: string, number, Date object',
   // parseValue and serialize are used to ensure validity
   parseValue: (value) => {
-    return typeof value === 'object' || typeof value === 'string' || typeof value === 'number' 
-    ? value
+    return typeof value === 'object' || typeof value === 'string' || typeof value === 'number'
+      ? value
       : null;
   },
   serialize: (value) => {
-    return typeof value === 'object' || typeof value === 'string' || typeof value === 'number' 
-    ? value
+    return typeof value === 'object' || typeof value === 'string' || typeof value === 'number'
+      ? value
       : null;
   },
   parseLiteral: (ast: ValueNode) => {
@@ -27,9 +27,10 @@ export const ComparisonOperatorScalarType = scalarType({
       case Kind.STRING:
       case Kind.INT:
         return ast.value;
-      case Kind.OBJECT: return parseObject(ast);
+      case Kind.OBJECT:
+        return parseObject(ast);
       default:
-        return null
+        return null;
     }
   },
   asNexusMethod: 'compare',
@@ -40,6 +41,7 @@ const parseObject = (ast: ObjectValueNode) => {
   ast.fields.forEach((field) => {
     value[field.name.value] = parseAst(field.value);
   });
+  
   return value;
 };
 

--- a/packages/create-bison-app/template/graphql/modules/scalars.ts
+++ b/packages/create-bison-app/template/graphql/modules/scalars.ts
@@ -41,7 +41,7 @@ const parseObject = (ast: ObjectValueNode) => {
   ast.fields.forEach((field) => {
     value[field.name.value] = parseAst(field.value);
   });
-  
+
   return value;
 };
 

--- a/packages/create-bison-app/template/graphql/modules/shared.ts
+++ b/packages/create-bison-app/template/graphql/modules/shared.ts
@@ -14,11 +14,11 @@ export const StringFilter = inputObjectType({
     t.string('contains');
     t.string('endsWith');
     t.string('equals');
-    t.string('gt');
-    t.string('gte');
+    t.compare('gt');
+    t.compare('gte');
     t.list.nonNull.string('in');
-    t.string('lt');
-    t.string('lte');
+    t.compare('lt');
+    t.compare('lte');
     t.list.nonNull.string('notIn');
     t.string('startsWith');
   },

--- a/packages/create-bison-app/template/graphql/modules/shared.ts
+++ b/packages/create-bison-app/template/graphql/modules/shared.ts
@@ -14,12 +14,40 @@ export const StringFilter = inputObjectType({
     t.string('contains');
     t.string('endsWith');
     t.string('equals');
-    t.compare('gt');
-    t.compare('gte');
+    t.string('gt');
+    t.string('gte');
     t.list.nonNull.string('in');
-    t.compare('lt');
-    t.compare('lte');
+    t.string('lt');
+    t.string('lte');
     t.list.nonNull.string('notIn');
     t.string('startsWith');
+  },
+});
+
+export const NumberFilter = inputObjectType({
+  name: 'NumberFilter',
+  description: 'A way to filter number fields. Meant to pass to prisma where clause',
+  definition(t) {
+    t.int('equals');
+    t.int('gt');
+    t.int('gte');
+    t.list.nonNull.int('in');
+    t.int('lt');
+    t.int('lte');
+    t.list.nonNull.int('notIn');
+  },
+});
+
+export const DateFilter = inputObjectType({
+  name: 'DateFilter',
+  description: 'A way to filter date fields. Meant to pass to prisma where clause',
+  definition(t) {
+    t.date('equals');
+    t.date('gt');
+    t.date('gte');
+    t.list.nonNull.date('in');
+    t.date('lt');
+    t.date('lte');
+    t.list.nonNull.date('notIn');
   },
 });


### PR DESCRIPTION


Adding updates that allow for comparison operators `gte`, `gt`, `lte`, `lt` to accept either `string`, `number`, or `object` without throwing TS errors

## Changes

- Added a `Comparison` custom scalar to be used with comparison operators `gte`, `gt`, `lte`, `lt`
- surfaced `compare` method in definition block using `asNexusMethod`


## Checklist

- [ ] Requires dependency update?
- [x ] Generating a new app works

Fixes #xxx
