### PR TITLE
ci: add os matrix to run tests on windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,5 @@
 name: Run Tests
+
 on:
   push:
     branches:
@@ -7,21 +8,14 @@ on:
   pull_request:
 
 jobs:
-  release:
-    name: Run
-    runs-on: ubuntu-20.04
-    services:
-      postgres:
-        image: postgres:11.5
-        env:
-          POSTGRES_PASSWORD: postgres
-        ports: ["5432:5432"]
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
+  create-app:
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
-      max-parallel: 1
+        os: ["ubuntu-latest", "windows-latest"]
+        node-version: [14.x, 16.x]
+    outputs:
+      appName: ${{ steps.create-app.outputs.appName }}
 
     steps:
       - name: Checkout
@@ -55,36 +49,70 @@ jobs:
         # Sets outputs.appPath to the created directory and outputs.appName
         run: node ./packages/create-bison-app/scripts/createApp bison-ci-app --acceptDefaults
 
+      - name: Upload bison app
+        uses: actions/upload-artifact@v2
+        if: matrix.os == 'ubuntu-latest'
+        with:
+          name: ${{ steps.create-app.outputs.appName }}
+          path: |
+            ${{ steps.create-app.outputs.appPath }}/
+            !${{ steps.create-app.outputs.appPath }}/node_modules
+          retention-days: 1
+
+  test:
+    needs: create-app
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports: ["5432:5432"]
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x]
+
+    steps:
+      - name: Download bison app
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ needs.create-app.outputs.appName }}
+
+      - name: Set up node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install bison app packages
+        run: yarn install
+
       - name: Build production bison app
-        working-directory: ${{ steps.create-app.outputs.appPath }}
         run: yarn build
 
       - name: Lint bison app
-        working-directory: ${{ steps.create-app.outputs.appPath }}
         run: yarn lint
 
       - name: Set up test database
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost/${{ steps.create-app.outputs.appName }}_test
+          DATABASE_URL: postgresql://postgres:postgres@localhost/${{ needs.create-app.outputs.appName }}_test
           NODE_ENV: test
-        working-directory: ${{ steps.create-app.outputs.appPath }}
         run: yarn db:migrate
 
       - name: Run bison app unit tests
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost/${{ steps.create-app.outputs.appName }}_test
+          DATABASE_URL: postgresql://postgres:postgres@localhost/${{ needs.create-app.outputs.appName }}_test
           NODE_ENV: test
-        working-directory: ${{ steps.create-app.outputs.appPath }}
         run: yarn test:ci
 
       - name: Run bison app E2E tests
         uses: cypress-io/github-action@v2
         with:
-          working-directory: ${{ steps.create-app.outputs.appPath }}
           start: yarn test:server
           wait-on: "http://localhost:3001"
         env:
           APP_SECRET: foo
-          DATABASE_URL: postgresql://postgres:postgres@localhost/${{ steps.create-app.outputs.appName }}_test
+          DATABASE_URL: postgresql://postgres:postgres@localhost/${{ needs.create-app.outputs.appName }}_test
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_ENV: test

--- a/packages/create-bison-app/template/package.json.ejs
+++ b/packages/create-bison-app/template/package.json.ejs
@@ -117,9 +117,9 @@
     "start-server-and-test": "^1.14.0",
     "supertest": "^4.0.2",
     "ts-jest": "^27.0.5",
-    "ts-node-dev": "^1.1.8",
-    "tsconfig-paths": "^3.12.0",
-    "typescript": "^4.4.3"
+    "ts-node-dev": "^2.0.0-0",
+    "tsconfig-paths": "^4.0.0",
+    "typescript": "^4.7.2"
   },
   "bison": {
     "version": "<%= bisonVersion %>"

--- a/packages/create-bison-app/utils/copyDirectoryWithTemplate.js
+++ b/packages/create-bison-app/utils/copyDirectoryWithTemplate.js
@@ -26,11 +26,16 @@ async function copyDirectoryWithTemplate(from, to, variables) {
     console.error("error making directory", e);
   }
 
-  const files = await globby([`${from}/**`], { expandDirectories: true });
+  // Glob patterns can only contain forward-slashes (even on Windows)
+  const globPattern = `${from.replace(/\\/g, '/')}/**`;
+  const files = await globby([globPattern], { expandDirectories: true });
 
   return await Promise.all(
     files.map(async (file) => {
-      const toFile = cleanTemplateDestPath(file.replace(from, to));
+      // Normalize the file path for Windows to ensure back-slashes are used
+      const filePath = path.normalize(file);
+
+      const toFile = cleanTemplateDestPath(filePath.replace(from, to));
       return copyWithTemplate(file, toFile, variables);
     })
   );


### PR DESCRIPTION
## Changes

https://github.com/echobind/bisonapp/actions/runs/2386787858

- Refactors CI into multiple jobs. I did remove Node 18 from the node matrix, just because it seems excessive after introducing the OS matrix.
   -  "create-app" Job
      -  this runs on both Windows and Ubuntu 
      - this will create a new bison app to ensure our CLI functionality works and uploads the app as an artifact
   - "test" Job
     -  this runs on Ubuntu only because a Postgres container is required and is only supported in Linux environments
     - this downloads the app artifact from the previous job and will run lint, unit and end-to-end tests
- Fixes bugs in Windows copying template files when creating a new app
- Had to upgrade TypeScript and related dependencies to fix new errors with `ts-node-dev`. These would occur in new bison apps even without any changes introduced by this PR.

Fixes #127 