### PR TITLE
fix: Update the initial database migration to include recent changes to schema.prisma.

### DIFF
--- a/packages/create-bison-app/template/prisma/migrations/20210322221918_initial-migration/migration.sql
+++ b/packages/create-bison-app/template/prisma/migrations/20210322221918_initial-migration/migration.sql
@@ -18,7 +18,7 @@ CREATE TABLE "User" (
     "id" TEXT NOT NULL,
     "email" TEXT NOT NULL,
     "password" TEXT NOT NULL,
-    "roles" "Role"[],
+    "roles" "Role"[] DEFAULT ARRAY['USER']::"Role"[],
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
 

--- a/packages/create-bison-app/template/prisma/migrations/20210322221918_initial-migration/migration.sql
+++ b/packages/create-bison-app/template/prisma/migrations/20210322221918_initial-migration/migration.sql
@@ -10,7 +10,7 @@ CREATE TABLE "Profile" (
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
 
-    PRIMARY KEY ("id")
+    CONSTRAINT "Profile_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
@@ -22,14 +22,14 @@ CREATE TABLE "User" (
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
 
-    PRIMARY KEY ("id")
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "Profile.userId_unique" ON "Profile"("userId");
+CREATE UNIQUE INDEX "Profile_userId_key" ON "Profile"("userId");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "User.email_unique" ON "User"("email");
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
 
 -- AddForeignKey
-ALTER TABLE "Profile" ADD FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Profile" ADD CONSTRAINT "Profile_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
A [recent PR](https://github.com/echobind/bisonapp/pull/270) introduced a change to `schema.prisma` that made it so a new Bison app will need to immediately create/run a new migration. This PR updates the initial database migration to include these changes.

I generated the file by:

1. Create a new Bison app.
2. Remove all the migration files.
5. Run `yarn db:migrate`.

This created a new Prisma migration for the entire database. I then copied this into the PR.

## Checklist

- [x] Generating a new app works
