### PR TITLE
chore: Use setup-node action to cache yarn deps in github actions workflow.

### DIFF
--- a/packages/create-bison-app/template/.github/workflows/main.js.yml.ejs
+++ b/packages/create-bison-app/template/.github/workflows/main.js.yml.ejs
@@ -35,6 +35,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+          # This will cache the packages that yarn installs
           cache: yarn
 
       # Yarn install

--- a/packages/create-bison-app/template/.github/workflows/main.js.yml.ejs
+++ b/packages/create-bison-app/template/.github/workflows/main.js.yml.ejs
@@ -35,18 +35,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: yarn
 
-      # Yarn cache/install
-      - name: Find yarn cache location
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: JS package cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+      # Yarn install
       - name: Install packages
         run: |
           yarn install --frozen-lockfile


### PR DESCRIPTION
[setup-node](https://github.com/actions/setup-node/) will cache packages on its own. C.f.:

- https://github.com/actions/setup-node#caching-global-packages-data
- https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data

This PR removes our custom caching and replaces it with setup-node's own cache.

I tested this on Clerestory.  "Control" is the old workflow, "Update" is the new workflow.

  | Control 1 | Control 2 | Update 1 | Update 2
-- | -- | -- | -- | --
  | 103 | 57 | 79 | 79
  | 66 | 76 | 80 | 110
  | 68 | 61 | 78 | 90
  | 71 | 68 | 85 | 77
  | 68 | 73 | 87 | 108
**Average** | **75.2** | **67** | **81.8** | **92.8**

It looks like it's a little slower. Maybe not a beneficial change? It could be that `node-setup` is doing some extra things that we aren't. But if that doesn't benefit us in terms of runtime, it's probably not worth it. Some pros and cons:

**Pros**

1. `node-setup` will presumably continue to improve. It could also just be GA's inconsistency in runtimes.
2. It's simpler.

**Cons**

1. Potentially slower, but it's hard to tell for sure.
2. It isn't as explicit as the old solution. I could see someone implementing the old solution again because they think caching is missing. That might not make it past PR review to get into Bison again, but someone who uses it to build a project could easily think that.


## Checklist

- [x] Generating a new app works

