### PR TITLE
chore: Remove comments that reference local storage for the auth token.

### DIFF
--- a/packages/create-bison-app/template/context/auth.tsx
+++ b/packages/create-bison-app/template/context/auth.tsx
@@ -31,7 +31,7 @@ function AuthProvider({ ...props }: Props) {
   const [loadCurrentUser, { called, data, loading, refetch }] = useMeLazyQuery();
   const user = data?.me;
 
-  // Load current user if there's an item in local storage
+  // Load current user if there's a token
   useEffect(() => {
     if (called) return;
 

--- a/packages/create-bison-app/template/lib/apolloClient.ts
+++ b/packages/create-bison-app/template/lib/apolloClient.ts
@@ -31,9 +31,8 @@ export function createApolloClient(ctx?: Record<string, any>) {
   });
 
   const authLink = setContext((_, { headers }) => {
-    // get the authentication token from local storage if it exists
+    // get the authentication token if it exists
     const token = cookies().get(LOGIN_TOKEN_KEY);
-    // const token = localStorage.getItem(LOGIN_TOKEN_KEY);
     // return the headers to the context so httpLink can read them
     return {
       headers: {


### PR DESCRIPTION
We no longer use local storage to store the auth token. There are a few references left in the code to local storage. This PR removes them.

## Checklist

- [x] Generating a new app works
