### PR TITLE
fix: Login session lifetime could be shorter than expected.

### DIFF
--- a/packages/create-bison-app/template/context/auth.tsx
+++ b/packages/create-bison-app/template/context/auth.tsx
@@ -6,9 +6,9 @@ import { useMeLazyQuery, User } from '@/types';
 import { FullPageSpinner } from '@/components/FullPageSpinner';
 import { LOGIN_TOKEN_KEY } from '@/constants';
 
-const now = new Date();
-const timeValidInMs = 365 * 24 * 60 * 60 * 1000;
-const COOKIE_EXPIRE_DATE = new Date(now.getTime() + timeValidInMs);
+const oneYearMs = 365 * 24 * 60 * 60 * 1000;
+// how long a login session lasts in milliseconds
+const sessionLifetimeMs = oneYearMs;
 
 const AuthContext = createContext<AuthContextObject>({
   login: () => ({}),
@@ -53,7 +53,10 @@ function AuthProvider({ ...props }: Props) {
    * @param token the token to login with
    */
   function login(token: string) {
-    cookies().set(LOGIN_TOKEN_KEY, token, { path: '/', expires: COOKIE_EXPIRE_DATE });
+    cookies().set(LOGIN_TOKEN_KEY, token, {
+      path: '/',
+      expires: new Date(Date.now() + sessionLifetimeMs),
+    });
 
     const fetchUserData = called ? refetch : loadCurrentUser;
     return fetchUserData();
@@ -63,7 +66,7 @@ function AuthProvider({ ...props }: Props) {
    * Logs out a user by removing their token from cookies.
    */
   async function logout() {
-    cookies().remove(LOGIN_TOKEN_KEY, { path: '/', expires: COOKIE_EXPIRE_DATE });
+    cookies().remove(LOGIN_TOKEN_KEY, { path: '/' });
 
     // TODO: remove from cache rather than call API
     const fetchUserData = called ? refetch : loadCurrentUser;


### PR DESCRIPTION
In `context/auth`, since `now` is defined outside of the component, `COOKIE_EXPIRE_DATE` will always be the same value as long as the user doesn't refresh the browser. So if we allow users to stay logged in for 30 days, a user loads the page, keeps their browser open for 29 days, then logs in, their session will only last 1 day.

Probably not a huge deal (especially since our default session lifetime is 1 year). But it could be an issue if someone wants to use very short sessions.

## Changes

- This PR computes the session lifetime on login, when the token cookie is set.

I generated an app and logged in. The session lifetime is still one year, as expected.

## Checklist

- [x] Generating a new app works
