### PR TITLE
chore: Remove unnecessary React imports.

### DIFF
--- a/packages/create-bison-app/template/README.md.ejs
+++ b/packages/create-bison-app/template/README.md.ejs
@@ -339,7 +339,6 @@ Now that we have the API finished, we can move to the frontend changes.
 - [ ] Add a simple form with a name input. See the [React Hook Form docs](https://react-hook-form.com) for detailed information.
 
 ```tsx
-import React from 'react';
 import { useForm } from 'react-hook-form';
 
 export function OrganizationForm() {
@@ -449,7 +448,6 @@ You should now have a fully working form that creates a new database entry on su
 - [ ] Add a query to the cell that fetches organization data
 
 ```jsx
-import React from 'react';
 import gql from 'graphql-tag';
 import { Spinner, Text } from '@chakra-ui/react';
 
@@ -511,7 +509,6 @@ export const QUERY = gql`
 - [ ] Only render the `Success` component if `data.organization` is present.
 
 ```tsx
-import React from 'react';
 import gql from 'graphql-tag';
 import { Spinner, Text } from '@chakra-ui/react';
 
@@ -551,7 +548,6 @@ export const OrganizationCell = ({ organizationId }) => {
 - [ ] Add the Cell to the organization page:
 
 ```tsx
-import React from 'react';
 import Head from 'next/head';
 import { Flex } from '@chakra-ui/react';
 import { useRouter } from 'next/router';

--- a/packages/create-bison-app/template/_.gitignore
+++ b/packages/create-bison-app/template/_.gitignore
@@ -15,6 +15,9 @@ out/
 # nexus
 .nexus
 
+# typescript
+tsconfig.tsbuildinfo
+
 # production
 /build
 

--- a/packages/create-bison-app/template/_templates/cell/new/new.ejs
+++ b/packages/create-bison-app/template/_templates/cell/new/new.ejs
@@ -3,7 +3,6 @@ to: cells/<%= [h.inflection.camelize(h.dirName(name)), h.camelizedBaseName(name)
 ---
 <% formattedPath = h.camelizedPathName(name) -%>
 <% component = h.camelizedBaseName(name) -%>
-import React from 'react';
 import gql from 'graphql-tag';
 import { Spinner, Text } from '@chakra-ui/react';
 

--- a/packages/create-bison-app/template/_templates/component/new/new.ejs
+++ b/packages/create-bison-app/template/_templates/component/new/new.ejs
@@ -3,7 +3,6 @@ to: components/<%= [h.inflection.camelize(h.dirName(name)), h.camelizedBaseName(
 ---
 <% formattedPath = h.camelizedPathName(name) -%>
 <% component = h.camelizedBaseName(name) -%>
-import React from 'react';
 import { Heading, Center } from '@chakra-ui/react';
 
 /** Description of component */

--- a/packages/create-bison-app/template/_templates/page/new/new.ejs
+++ b/packages/create-bison-app/template/_templates/page/new/new.ejs
@@ -4,7 +4,6 @@ to: pages/<%= name %>.tsx
 <% formattedPath = h.camelizedPathName(name).replace('/','') -%>
 <% pageName = `${formattedPath}Page` -%>
 <% base = h.camelizedBaseName(name) -%>
-import React from 'react';
 import Head from 'next/head';
 import { Heading, Center, Flex } from '@chakra-ui/react';
 

--- a/packages/create-bison-app/template/_templates/test/component/component.ejs
+++ b/packages/create-bison-app/template/_templates/test/component/component.ejs
@@ -2,8 +2,6 @@
 to: tests/unit/components/<%= h.camelizedBaseName(name) %>.test.tsx
 ---
 <% component = h.camelizedBaseName(name) -%>
-import React from 'react';
-
 import { render } from '@/tests/utils';
 import { <%= component %> } from '@/components/<%= component %>';
 

--- a/packages/create-bison-app/template/_templates/test/component/component.ejs
+++ b/packages/create-bison-app/template/_templates/test/component/component.ejs
@@ -2,6 +2,8 @@
 to: tests/unit/components/<%= h.camelizedBaseName(name) %>.test.tsx
 ---
 <% component = h.camelizedBaseName(name) -%>
+import React from 'react';
+
 import { render } from '@/tests/utils';
 import { <%= component %> } from '@/components/<%= component %>';
 

--- a/packages/create-bison-app/template/components/AllProviders.tsx
+++ b/packages/create-bison-app/template/components/AllProviders.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import { ApolloClient, ApolloProvider, NormalizedCacheObject } from '@apollo/client';
 import { ChakraProvider, CSSReset } from '@chakra-ui/react';
 import { Dict } from '@chakra-ui/utils';
@@ -9,7 +9,7 @@ import defaultTheme from '@/chakra';
 
 interface Props {
   apolloClient?: ApolloClient<NormalizedCacheObject>;
-  children: React.ReactNode;
+  children: ReactNode;
   theme?: Dict<any>;
 }
 

--- a/packages/create-bison-app/template/components/CenteredBoxForm.tsx
+++ b/packages/create-bison-app/template/components/CenteredBoxForm.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import { Box } from '@chakra-ui/react';
 
 interface Props {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 /** A form with a centered box. Ex: Login, Signup */

--- a/packages/create-bison-app/template/components/ErrorText.tsx
+++ b/packages/create-bison-app/template/components/ErrorText.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Text, TextProps } from '@chakra-ui/react';
 
 /** Renders error text under form inputs */

--- a/packages/create-bison-app/template/components/FullPageSpinner.tsx
+++ b/packages/create-bison-app/template/components/FullPageSpinner.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Spinner, Center } from '@chakra-ui/react';
 
 /** Renders a full page loading spinner */

--- a/packages/create-bison-app/template/components/Link.tsx
+++ b/packages/create-bison-app/template/components/Link.tsx
@@ -1,6 +1,5 @@
 import type { PropsWithChildren } from 'react';
 import type { LinkProps as NextLinkProps } from 'next/link';
-import React from 'react';
 import NextLink from 'next/link';
 import {
   Button as ChakraButton,

--- a/packages/create-bison-app/template/components/LoginForm.tsx
+++ b/packages/create-bison-app/template/components/LoginForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { Flex, Text, FormControl, FormLabel, Input, Stack, Button, Circle } from '@chakra-ui/react';
 import { useForm } from 'react-hook-form';

--- a/packages/create-bison-app/template/components/Logo.tsx
+++ b/packages/create-bison-app/template/components/Logo.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Heading } from '@chakra-ui/react';
 
 import { Link } from './Link';

--- a/packages/create-bison-app/template/components/Nav.tsx
+++ b/packages/create-bison-app/template/components/Nav.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Stack,
   useBreakpoint,

--- a/packages/create-bison-app/template/components/SignupForm.tsx
+++ b/packages/create-bison-app/template/components/SignupForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Flex, Text, FormControl, FormLabel, Input, Stack, Button, Circle } from '@chakra-ui/react';
 import { gql } from '@apollo/client';
 import { useForm } from 'react-hook-form';

--- a/packages/create-bison-app/template/context/auth.tsx
+++ b/packages/create-bison-app/template/context/auth.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, ReactNode, useState, useEffect } from 'react';
+import { createContext, useContext, ReactNode, useState, useEffect } from 'react';
 import { gql } from '@apollo/client';
 
 import { cookies } from '@/lib/cookies';

--- a/packages/create-bison-app/template/jest.config.js
+++ b/packages/create-bison-app/template/jest.config.js
@@ -27,7 +27,7 @@ module.exports = {
   globals: {
     'ts-jest': {
       tsconfig: {
-        jsx: 'react',
+        jsx: 'react-jsx',
       },
     },
   },
@@ -35,6 +35,6 @@ module.exports = {
     ...moduleNameMapper,
     // Handle image imports
     // https://jestjs.io/docs/webpack#handling-static-assets
-    '^.+\\.(png|jpg|jpeg|gif|webp|avif|ico|bmp|svg)$/i': `<rootDir>/__mocks__/fileMock.js`
-  }
+    '^.+\\.(png|jpg|jpeg|gif|webp|avif|ico|bmp|svg)$/i': `<rootDir>/__mocks__/fileMock.js`,
+  },
 };

--- a/packages/create-bison-app/template/layouts/LoggedIn.tsx
+++ b/packages/create-bison-app/template/layouts/LoggedIn.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import { useRouter } from 'next/router';
 import { Box, Flex, Button } from '@chakra-ui/react';
 
@@ -8,7 +8,7 @@ import { useAuth } from '@/context/auth';
 import { Footer } from '@/components/Footer';
 
 interface Props {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 export function LoggedInLayout({ children }: Props) {

--- a/packages/create-bison-app/template/layouts/LoggedOut.tsx
+++ b/packages/create-bison-app/template/layouts/LoggedOut.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import { Box, Flex } from '@chakra-ui/react';
 
 import { ButtonLink } from '@/components/Link';
@@ -6,7 +6,7 @@ import { Logo } from '@/components/Logo';
 import { Footer } from '@/components/Footer';
 
 interface Props {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 export function LoggedOutLayout({ children }: Props) {

--- a/packages/create-bison-app/template/pages/_app.tsx
+++ b/packages/create-bison-app/template/pages/_app.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import type { AppProps } from 'next/app';
 import dynamic from 'next/dynamic';
 
@@ -9,18 +9,18 @@ import { useAuth } from '@/context/auth';
  * Dynamically load layouts. This codesplits and prevents code from the logged in layout from being
  * included in the bundle if we're rendering the logged out layout.
  */
-const LoggedInLayout = dynamic<{ children: React.ReactNode }>(() =>
+const LoggedInLayout = dynamic<{ children: ReactNode }>(() =>
   import('@/layouts/LoggedIn').then((mod) => mod.LoggedInLayout)
 );
 
-const LoggedOutLayout = dynamic<{ children: React.ReactNode }>(() =>
+const LoggedOutLayout = dynamic<{ children: ReactNode }>(() =>
   import('@/layouts/LoggedOut').then((mod) => mod.LoggedOutLayout)
 );
 
 /**
  * Renders a layout depending on the result of the useAuth hook
  */
-function AppWithAuth({ children }: { children: React.ReactNode }) {
+function AppWithAuth({ children }: { children: ReactNode }) {
   const { user } = useAuth();
 
   return user ? (

--- a/packages/create-bison-app/template/pages/index.tsx
+++ b/packages/create-bison-app/template/pages/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Head from 'next/head';
 import { Heading, Center } from '@chakra-ui/react';
 

--- a/packages/create-bison-app/template/pages/login.tsx
+++ b/packages/create-bison-app/template/pages/login.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Head from 'next/head';
 
 import { CenteredBoxForm } from '@/components/CenteredBoxForm';

--- a/packages/create-bison-app/template/pages/signup.tsx
+++ b/packages/create-bison-app/template/pages/signup.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Head from 'next/head';
 
 import { CenteredBoxForm } from '@/components/CenteredBoxForm';

--- a/packages/create-bison-app/template/tests/unit/components/CenteredBoxForm.test.tsx
+++ b/packages/create-bison-app/template/tests/unit/components/CenteredBoxForm.test.tsx
@@ -2,8 +2,6 @@
  * @jest-environment jsdom
  */
 
-import React from 'react';
-
 import { render } from '@/tests/utils';
 import { CenteredBoxForm } from '@/components/CenteredBoxForm';
 

--- a/packages/create-bison-app/template/tests/unit/components/ErrorText.test.tsx
+++ b/packages/create-bison-app/template/tests/unit/components/ErrorText.test.tsx
@@ -2,8 +2,6 @@
  * @jest-environment jsdom
  */
 
-import React from 'react';
-
 import { render } from '@/tests/utils';
 import { ErrorText } from '@/components/ErrorText';
 

--- a/packages/create-bison-app/template/tests/unit/components/LoginForm.test.tsx
+++ b/packages/create-bison-app/template/tests/unit/components/LoginForm.test.tsx
@@ -2,8 +2,6 @@
  * @jest-environment jsdom
  */
 
-import React from 'react';
-
 import { render, waitFor, userEvent } from '@/tests/utils';
 import { LoginForm } from '@/components/LoginForm';
 

--- a/packages/create-bison-app/template/tests/unit/components/Logo.test.tsx
+++ b/packages/create-bison-app/template/tests/unit/components/Logo.test.tsx
@@ -2,8 +2,6 @@
  * @jest-environment jsdom
  */
 
-import React from 'react';
-
 import { render } from '@/tests/utils';
 import { Logo } from '@/components/Logo';
 

--- a/packages/create-bison-app/template/tests/unit/components/Nav.test.tsx
+++ b/packages/create-bison-app/template/tests/unit/components/Nav.test.tsx
@@ -2,8 +2,6 @@
  * @jest-environment jsdom
  */
 
-import React from 'react';
-
 import { render } from '@/tests/utils';
 import '@/tests/matchMedia.mock';
 import { Nav } from '@/components/Nav';

--- a/packages/create-bison-app/template/tests/unit/components/SignupForm.test.tsx
+++ b/packages/create-bison-app/template/tests/unit/components/SignupForm.test.tsx
@@ -2,8 +2,6 @@
  * @jest-environment jsdom
  */
 
-import React from 'react';
-
 import { render, waitFor, userEvent } from '@/tests/utils';
 import { SignupForm } from '@/components/SignupForm';
 

--- a/packages/create-bison-app/template/tests/utils.tsx
+++ b/packages/create-bison-app/template/tests/utils.tsx
@@ -1,5 +1,4 @@
 import '@testing-library/jest-dom';
-import React from 'react';
 import { render as defaultRender } from '@testing-library/react';
 // import { MockedProvider, MockedResponse } from '@apollo/react-testing';
 import { RouterContext } from 'next/dist/shared/lib/router-context';


### PR DESCRIPTION
Since we're using Next.js we don't need to import `React` in every `.tsx` file. It's done automatically.

## Changes

- Remove all unnecessary `import React from "react";`
- Add `tsconfig.tsbuildinfo` to .gitignore. I've been noticing this file pop up after generating types.


## Checklist

- [x] Generating a new app works
