### PR TITLE
Mini RFC: Postgres dbgenerated 

### DIFF
--- a/packages/create-bison-app/template/prisma/migrations/20221130190951_initial_migration/migration.sql
+++ b/packages/create-bison-app/template/prisma/migrations/20221130190951_initial_migration/migration.sql
@@ -3,34 +3,34 @@ CREATE TYPE "Role" AS ENUM ('ADMIN', 'USER');
 
 -- CreateTable
 CREATE TABLE "Profile" (
-    "id" TEXT NOT NULL,
-    "userId" TEXT NOT NULL,
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "userId" UUID NOT NULL,
     "firstName" TEXT NOT NULL,
     "lastName" TEXT NOT NULL,
     "image" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT "Profile_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
 CREATE TABLE "User" (
-    "id" TEXT NOT NULL,
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
     "email" TEXT NOT NULL,
     "emailVerified" TIMESTAMP(3),
     "password" TEXT,
-    "roles" "Role"[],
+    "roles" "Role"[] DEFAULT ARRAY['USER']::"Role"[],
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT "User_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
 CREATE TABLE "Account" (
-    "id" TEXT NOT NULL,
-    "userId" TEXT NOT NULL,
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "userId" UUID NOT NULL,
     "type" TEXT NOT NULL,
     "provider" TEXT NOT NULL,
     "providerAccountId" TEXT NOT NULL,
@@ -47,9 +47,9 @@ CREATE TABLE "Account" (
 
 -- CreateTable
 CREATE TABLE "Session" (
-    "id" TEXT NOT NULL,
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
     "sessionToken" TEXT NOT NULL,
-    "userId" TEXT NOT NULL,
+    "userId" UUID NOT NULL,
     "expires" TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "Session_pkey" PRIMARY KEY ("id")

--- a/packages/create-bison-app/template/prisma/schema.prisma
+++ b/packages/create-bison-app/template/prisma/schema.prisma
@@ -12,32 +12,32 @@ datasource db {
 }
 
 model Profile {
-  id        String   @id @default(cuid())
-  userId    String   @unique
+  id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId    String   @unique @db.Uuid
   firstName String
   lastName  String
   image     String?
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model User {
-  id            String    @id @default(cuid())
+  id            String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   email         String    @unique
   emailVerified DateTime?
   password      String?
-  roles         Role[]
+  roles         Role[]    @default([USER])
   createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
+  updatedAt     DateTime  @default(now()) @updatedAt
   profile       Profile?
   accounts      Account[]
   sessions      Session[]
 }
 
 model Account {
-  id                String  @id @default(cuid())
-  userId            String
+  id                String  @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId            String  @db.Uuid
   type              String
   provider          String
   providerAccountId String
@@ -55,9 +55,9 @@ model Account {
 }
 
 model Session {
-  id           String   @id @default(cuid())
+  id           String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   sessionToken String   @unique
-  userId       String
+  userId       String   @db.Uuid
   expires      DateTime
   user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }


### PR DESCRIPTION
## Changes 
- Allow Postgres to generate Primary Ids (UUID) vs Prisma (CUID) -- built in as of Postgres13
- Allow updatedAt to have a default now value 
- Add a default Enum where it makes sense
- Lean into `@db` utils to allow for a more DB forward schema/validations 

**Misc** 
- I had to update my CI Postgres from 11.5 to 15 in my latest Bison create... However 
- It looks like someone already updated our CI flow in `Canary` to Postgres 15 (*could use a release)

## TLDR
It allows for the flexibility to utilize `pg` in the terminal or a DB Viewer when creating and making one-off edits. 
**For larger migrations, you'd still utilize our Prisma Factories. 

![image](https://user-images.githubusercontent.com/17518011/204893848-b3358ebb-6505-44f7-8666-7635370f2ef3.png)

## RFC Notes 
dbgenerated > Prisma 
Loom: <https://www.loom.com/share/eac06de2eb1a4a82bfcb0f4cc80b0541>

Reasoning: 
- not everyone runs through the UI or Prisma Factories.
- It's not easy to change later
- The underlying SQL being more strict 
`"id" TEXT NOT NULL` VS `"id" UUID NOT NULL DEFAULT gen_random_uuid()`

Viewpoint: Not all of our clients have a full-stack team of engineers. 
For some of the larger enterprise clients, there's a person for DB, Backend, Frontend, Ops, etc. 
I've met some resistance from folks worried about ORMs and what they are doing. 
They look to have as much control as they can at the DB level. 
This would allow folks to see the raw SQL and run in `pg` in their normal day-to-day. 

Similar for smaller clients. Having to set up a script file to add one person is a bit more verbose than it needs to be. They'd rather hop into the terminal and give their new employee access on the fly. While we want to encourage best practices, most of these folks just want to dive in quickly and move on with their day. 

This change isn't a make-or-break change -- more of a nice Dev experience allowing all of our options to stay open. 
The worst case is you copy a timestamp and cuid and slightly alter it. (what I do today) 

Using the generated DB fields is a low LOE for us. It also allows folks to continue learning what happens at the DB level should something change (MySQL vs Postgres for example). We've marked learnings like this as a Pro as well in tRPC land, where we need to start understanding joins and selects better. I feel this falls in the same category of "What is this tool doing for us" and being aware of what is happening. 

There are also other `@db` utils that could be learned/leveraged as we dive into Prisma/Postgres more. 
Types of Date/Time Timestamps, String types, Varchar length, etc. 

## Opinion/Preference
Lean into the DB as much as possible and allow Prisma to help normalize types for the app. 

## Questions 
I'm curious if others have opinions, concerns, etc. 
So far it seems like a minor preference change -- but correct me if I'm wrong. 

## Alternatives
I recall there being a Prisma shell similar to `rails c` that maybe would allow for us to do one-offs but I have yet to try. (if it still exists) I don't think this would be able to leverage our Factories, but it would utilize the core schema file. 
