### PR TITLE
feat: Add docker-compose.yml to the Bison template.

### DIFF
--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -1,21 +1,23 @@
-# Run Postgres with Bison 
+# Run Postgres with Bison
 
 1. Setup a database locally ([Postgres](https://postgresapp.com/downloads.html) is the only type fully supported right now)
 1. Make sure your database user has permission to create schemas and databases. We recommend using a superuser account locally to keep things easy.
 1. Setup your local database with `yarn db:setup`. You'll be prompted to create it if it doesn't already exist:1. Setup a database locally ([Postgres](https://postgresapp.com/downloads.html) is the only type fully supported right now)
 1. Make sure your database user has permission to create schemas and databases. We recommend using a superuser account locally to keep things easy.
 1. Setup your local database with `yarn db:setup`. You'll be prompted to create it if it doesn't already exist:
-When creating a bison app, you are prompted with questions to set up your app along with Postgres. 
+   When creating a bison app, you are prompted with questions to set up your app along with Postgres.
 
 ![Prisma DB Create Prompt](https://user-images.githubusercontent.com/14339/88480536-7e1fb180-cf24-11ea-85c9-9bed43c9dfe4.png)
 
 Need help setting up Postgres locally?
 
-#### Install Postgres on Mac
-Mac: https://postgresapp.com/
+## Install Postgres on Mac
 
-#### Install Postgres on Windows
-Windows: https://www.postgresql.org/download/windows/
+Mac: <https://postgresapp.com/>
+
+## Install Postgres on Windows
+
+Windows: <https://www.postgresql.org/download/windows/>
 
 ## Run Postgres with Docker
 
@@ -40,41 +42,46 @@ services:
       POSTGRES_PASSWORD: dev
       POSTGRES_DB: dev
 ```
+
 A different schema is created for your testing data.
 
-Please note the ports to adjust your environment variables. See below for an example. 
+Please note the ports to adjust your environment variables. See below for an example.
 
 Add `.data/` to your `.gitignore`
 
-#### Edit your environment variables:
+### Edit your environment variables
+
 Change the database URL in `.env.local`:
-```
+
+```bash
 DATABASE_URL="postgres://dev:dev@postgres:5433/dev?schema=public"
 ```
 
 and
 
 `.env.test`
-```
+
+```bash
 DATABASE_URL="postgres://dev:dev@postgres:5433/dev?schema=testing"
 ```
 
 **Note**: When creating a bison app, if you answered something else rather than `dev` when prompted, "What is the local test database
-name?" You will have to set the variable `testDabaseName` to `dev` in `test/jest.setup.js` file.
+name?" You will have to set the variable `testDatabaseName` to `dev` in `test/jest.setup.js` file.
 
 Run the following command in your terminal:
-`docker-compose up -d` 
+`docker-compose up -d`
 
 To shut it down:
 `docker-compose down`
 
 ## Optional - Package.json
+
 Add the following to your `package.json`
 
 ```json
 "scripts": {
   "docker:up": "docker-compose up -d",
-  "docker:down" "docker-compose down" 
+  "docker:down": "docker-compose down"
 }
 ```
 

--- a/packages/create-bison-app/tasks/copyFiles.js
+++ b/packages/create-bison-app/tasks/copyFiles.js
@@ -71,6 +71,12 @@ async function copyFiles({ variables, targetFolder }) {
       variables
     ),
 
+    copyWithTemplate(
+      fromPath("docker-compose.yml.ejs"),
+      toPath("docker-compose.yml"),
+      variables
+    ),
+
     copyDirectoryWithTemplate(
       fromPath(".github"),
       toPath(".github"),

--- a/packages/create-bison-app/template/_.gitignore
+++ b/packages/create-bison-app/template/_.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 /test-results/
 /playwright-report/
 /playwright/.cache/
+
+# data
+/.data

--- a/packages/create-bison-app/template/docker-compose.yml.ejs
+++ b/packages/create-bison-app/template/docker-compose.yml.ejs
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  db:
+    container_name: <%= name %>-db
+    image: 'postgres:14'
+    volumes:
+      - './.data/db:/var/lib/postgresql/data'
+    restart: 'always'
+    ports:
+      - <%= db.dev.port %>:5432
+    environment:
+      POSTGRES_USER: <%= db.dev.user %>
+      POSTGRES_DB: <%= db.dev.name %>
+<% if (db.dev.password) { -%>
+      POSTGRES_PASSWORD: <%= db.dev.password %>
+<% } -%>
+      TZ: 'Etc/UTC'

--- a/packages/create-bison-app/template/package.json.ejs
+++ b/packages/create-bison-app/template/package.json.ejs
@@ -43,7 +43,9 @@
     "test:e2e:debug": "PWDEBUG=1 yarn test:e2e",
     "ts-node": "ts-node-dev --project tsconfig.cjs.json -r tsconfig-paths/register",
     "withEnv:test": "dotenv -c test --",
-    "watch:ts": "yarn dev:typecheck --watch"
+    "watch:ts": "yarn dev:typecheck --watch",
+    "docker:up": "docker-compose up -d",
+    "docker:down": "docker-compose down" 
   },
   "dependencies": {
     "@chakra-ui/pro-theme": "^0.0.57",

--- a/packages/create-bison-app/template/package.json.ejs
+++ b/packages/create-bison-app/template/package.json.ejs
@@ -19,6 +19,8 @@
     "db:setup": "yarn db:reset",
     "dev": "next dev",
     "dev:typecheck": "tsc --noEmit",
+    "docker:up": "docker-compose up -d",
+    "docker:down": "docker-compose down",
     "g:cell": "hygen cell new --name",
     "g:component": "hygen component new --name",
     "g:trpc": "hygen trpc new --name",
@@ -43,9 +45,7 @@
     "test:e2e:debug": "PWDEBUG=1 yarn test:e2e",
     "ts-node": "ts-node-dev --project tsconfig.cjs.json -r tsconfig-paths/register",
     "withEnv:test": "dotenv -c test --",
-    "watch:ts": "yarn dev:typecheck --watch",
-    "docker:up": "docker-compose up -d",
-    "docker:down": "docker-compose down" 
+    "watch:ts": "yarn dev:typecheck --watch"
   },
   "dependencies": {
     "@chakra-ui/pro-theme": "^0.0.57",


### PR DESCRIPTION
I know we decided not to be opinionated about Docker in Bison a while back, but I just got frustrated having to create a `docker-compose.yml` every time I wanted to test out a Bison feature.

It's still optional (you don't need to use the `docker-compose` file).

## Changes

- feat: Add docker-compose.yml to the Bison template.

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works
