### PR TITLE
chore: Remove unstable keyword from getServerSession function

### DIFF
--- a/packages/create-bison-app/template/utils/getDefaultServerSideProps.ts
+++ b/packages/create-bison-app/template/utils/getDefaultServerSideProps.ts
@@ -1,7 +1,7 @@
 // Wrapper for unstable_getServerSession https://next-auth.js.org/configuration/nextjs
 
 import type { GetServerSidePropsContext } from 'next';
-import { unstable_getServerSession } from 'next-auth';
+import { getServerSession } from 'next-auth';
 
 import { authOptions as nextAuthOptions } from '@/pages/api/auth/[...nextauth]';
 
@@ -10,5 +10,5 @@ export const getServerAuthSession = async (ctx: {
   req: GetServerSidePropsContext['req'];
   res: GetServerSidePropsContext['res'];
 }) => {
-  return await unstable_getServerSession(ctx.req, ctx.res, nextAuthOptions);
+  return await getServerSession(ctx.req, ctx.res, nextAuthOptions);
 };


### PR DESCRIPTION
Removes `unstable` keyword from `getServerSession` function.

https://next-auth.js.org/configuration/nextjs#unstable_getserversession

## Changes

- Removes warning in the console. 

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works

Fixes #xxx
