### PR TITLE
ci: fix node12 warning

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Download bison app
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ needs.create-app.outputs.appName }}
 


### PR DESCRIPTION
## Changes

Upgrades GitHub action version to fix these warnings:
![Screen Shot 2023-04-28 at 1 55 05 PM](https://user-images.githubusercontent.com/1087679/235219468-e3332305-ba26-477b-bc33-345547011238.png)

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works

Fixes #300 