### PR TITLE
fix: update hygen templates to be generated in src directory

### DIFF
--- a/packages/create-bison-app/template/_templates/cell/new/new.ejs
+++ b/packages/create-bison-app/template/_templates/cell/new/new.ejs
@@ -1,5 +1,5 @@
 ---
-to: cells/<%= [h.inflection.camelize(h.dirName(name)), h.camelizedBaseName(name)].filter(Boolean).join('/') %>.tsx
+to: src/cells/<%= [h.inflection.camelize(h.dirName(name)), h.camelizedBaseName(name)].filter(Boolean).join('/') %>.tsx
 ---
 <% formattedPath = h.camelizedPathName(name) -%>
 <% component = h.camelizedBaseName(name) -%>

--- a/packages/create-bison-app/template/_templates/component/new/new.ejs
+++ b/packages/create-bison-app/template/_templates/component/new/new.ejs
@@ -1,5 +1,5 @@
 ---
-to: components/<%= [h.inflection.camelize(h.dirName(name)), h.camelizedBaseName(name)].filter(Boolean).join('/') %>.tsx
+to: src/components/<%= [h.inflection.camelize(h.dirName(name)), h.camelizedBaseName(name)].filter(Boolean).join('/') %>.tsx
 ---
 <% formattedPath = h.camelizedPathName(name) -%>
 <% component = h.camelizedBaseName(name) -%>

--- a/packages/create-bison-app/template/_templates/page/new/new.ejs
+++ b/packages/create-bison-app/template/_templates/page/new/new.ejs
@@ -1,5 +1,5 @@
 ---
-to: pages/<%= name %>.tsx
+to: src/pages/<%= name %>.tsx
 ---
 <% formattedPath = h.camelizedPathName(name).replace('/','') -%>
 <% pageName = `${formattedPath}Page` -%>

--- a/packages/create-bison-app/template/_templates/trpc/new/injectExport.ejs
+++ b/packages/create-bison-app/template/_templates/trpc/new/injectExport.ejs
@@ -1,6 +1,6 @@
 ---
 inject: true
-to: server/routers/_app.ts
+to: src/server/routers/_app.ts
 before: \}\);\n\nexport type AppRouter
 skip_if:   "<%= name %>: <%= name %>Router,"
 ---

--- a/packages/create-bison-app/template/_templates/trpc/new/injectImport.ejs
+++ b/packages/create-bison-app/template/_templates/trpc/new/injectImport.ejs
@@ -1,6 +1,6 @@
 ---
 inject: true
-to: server/routers/_app.ts
+to: src/server/routers/_app.ts
 before: \nimport \{ t \} from '@/server/trpc';
 skip_if: import { <%= h.inflection.camelize(name).toLowerCase() %>Router } from './<%= h.inflection.camelize(name).toLowerCase() %>';
 ---

--- a/packages/create-bison-app/template/_templates/trpc/new/trpc.ejs
+++ b/packages/create-bison-app/template/_templates/trpc/new/trpc.ejs
@@ -1,5 +1,5 @@
 ---
-to: server/routers/<%= name %>.ts
+to: src/server/routers/<%= name %>.ts
 ---
 <% camelized = h.inflection.camelize(name) -%>
 <% plural = h.inflection.pluralize(camelized) -%>


### PR DESCRIPTION
## Changes

Forgot to update the location where hygen templates are generated in the  #316 PR. This PR updates to the correct paths in the `src` directory.

## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works
