### PR TITLE
fix: Minor login improvements

### DIFF
--- a/packages/create-bison-app/template/src/components/CenteredBoxForm.tsx
+++ b/packages/create-bison-app/template/src/components/CenteredBoxForm.tsx
@@ -7,7 +7,7 @@ interface Props {
 /** A form with a centered box. Ex: Login, Signup */
 export function CenteredBoxForm({ children }: Props) {
   return (
-    <div className="m-auto rounded-xl w-full max-w-sm sm:shadow-md dark:sm:shadow-slate-600 p-8 my-4 lg:my-16 mx-8 lg:mx-auto">
+    <div className="m-auto rounded-xl w-full max-w-sm sm:shadow-md dark:sm:shadow-slate-600 p-8 my-4 lg:my-16 lg:mx-auto">
       {children}
     </div>
   );

--- a/packages/create-bison-app/template/src/components/auth/LoginForm.tsx
+++ b/packages/create-bison-app/template/src/components/auth/LoginForm.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { signIn } from 'next-auth/react';
 import { useForm } from 'react-hook-form';
-import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 
@@ -91,11 +90,11 @@ export function LoginForm() {
         </PasswordField>
       </div>
       <div className="flex justify-between">
-        <NextLink href="/reset-password">
-          <Button variant="link" size="sm">
+        <Link href="/reset-password">
+          <Button variant="link" size="sm" type="button">
             Forgot password?
           </Button>
-        </NextLink>
+        </Link>
       </div>
       <div className="flex gap-6 flex-col">
         <Button variant="outline" type="submit" disabled={loading} data-testid="login-submit">

--- a/packages/create-bison-app/template/src/layouts/LoggedIn.tsx
+++ b/packages/create-bison-app/template/src/layouts/LoggedIn.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from 'react';
-import { useRouter } from 'next/router';
 import { signOut } from 'next-auth/react';
 
 import { Logo } from '@/components/Logo';
@@ -12,11 +11,8 @@ interface Props {
 }
 
 export function LoggedInLayout({ children }: Props) {
-  const router = useRouter();
-
   async function handleLogout() {
-    signOut();
-    await router.replace('/login');
+    await signOut({ callbackUrl: '/login' });
   }
 
   return (


### PR DESCRIPTION
## Changes

- Fix an issue where the form justified to the left when resizing to a small viewport.
- Fix an issue where the router was not routing them to `/login` page after signing out.
- Fix an issue if you enter your email and password, and you press "enter," it redirects you to `/reset-password` when it should log you in.


## Checklist

- [ ] Requires dependency update?
- [x] Generating a new app works