### PR TITLE
chore: dependencies

### DIFF
--- a/packages/create-bison-app/template/package.json.ejs
+++ b/packages/create-bison-app/template/package.json.ejs
@@ -77,7 +77,6 @@
     "react-error-boundary": "^4.0.3",
     "superjson": "^1.13.1",
     "tailwind-merge": "^1.14.0",
-    "tailwindcss-animate": "^1.0.6",
     "universal-cookie": "^5.0.0",
     "zod": "^3.22.1"
   },
@@ -118,6 +117,7 @@
     "prettier": "^2.8.7",
     "prisma": "^5.1.1",
     "tailwindcss": "^3.3.3",
+    "tailwindcss-animate": "^1.0.6",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",

--- a/packages/create-bison-app/template/package.json.ejs
+++ b/packages/create-bison-app/template/package.json.ejs
@@ -117,7 +117,6 @@
     "postcss": "^8.4.28",
     "prettier": "^2.8.7",
     "prisma": "^5.1.1",
-    "start-server-and-test": "^2.0.0",
     "tailwindcss": "^3.3.3",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
## Changes

- remove unused `start-server-and-test` dependency, I think this was needed for Cypress
- moves `tailwindcss-animate` to dev dependencies

## Checklist

- [x] Requires dependency update?
- [ ] Generating a new app works
